### PR TITLE
fix: do not stack distances if empty

### DIFF
--- a/examples/hnsw_benchmark.py
+++ b/examples/hnsw_benchmark.py
@@ -16,7 +16,7 @@ def _precision(predicted, relevant, eval_at):
     """
     fraction of retrieved documents that are relevant to the query
     """
-    if eval_at == 0:
+    if eval_at == 0 or len(predicted)==0:
         return 0.0
     predicted_at_k = predicted[:eval_at]
     n_predicted_and_relevant = len(set(predicted_at_k).intersection(set(relevant)))
@@ -28,7 +28,7 @@ def _recall(predicted, relevant, eval_at):
     """
     fraction of the relevant documents that are successfully retrieved
     """
-    if eval_at == 0:
+    if eval_at == 0 or len(relevant)==0:
         return 0.0
     predicted_at_k = predicted[:eval_at]
     n_predicted_and_relevant = len(set(predicted_at_k).intersection(set(relevant)))

--- a/pqlite/container.py
+++ b/pqlite/container.py
@@ -100,26 +100,29 @@ class CellContainer:
 
                 indices = np.array(indices, dtype=np.int64)
 
-            _dists, _doc_idx = self.vec_index(cell_id).search(
-                x, limit=limit, indices=indices
-            )
+            if indices is not None:
+                _dists, _doc_idx = self.vec_index(cell_id).search(
+                    x, limit=limit, indices=indices
+                )
 
-            if count >= limit and _dists[0] > dists[-1][-1]:
-                continue
+                if count >= limit and _dists[0] > dists[-1][-1]:
+                    continue
 
-            dists.append(_dists)
-            doc_idx.append(_doc_idx)
-            cell_ids.extend([cell_id] * len(_dists))
-            count += len(_dists)
+                dists.append(_dists)
+                doc_idx.append(_doc_idx)
+                cell_ids.extend([cell_id] * len(_dists))
+                count += len(_dists)
 
-        cell_ids = np.array(cell_ids, dtype=np.int64)
-        dists = np.hstack(dists)
-        doc_idx = np.hstack(doc_idx)
-
-        indices = dists.argsort(axis=0)[:limit]
-        dists = dists[indices]
-        cell_ids = cell_ids[indices]
-        doc_idx = doc_idx[indices]
+        if len(dists) > 0:
+            cell_ids = np.array(cell_ids, dtype=np.int64)
+            dists = np.hstack(dists)
+            doc_idx = np.hstack(doc_idx)
+            indices = dists.argsort(axis=0)[:limit]
+            dists = dists[indices]
+            cell_ids = cell_ids[indices]
+            doc_idx = doc_idx[indices]
+        else:
+            logger.debug(f'=> No matches retrieved in any cell')
 
         doc_ids = []
         for cell_id, offset in zip(cell_ids, doc_idx):


### PR DESCRIPTION
prevents ivf to break in case nothing is retrieved.