### PR TITLE
fix: ivf search problem when 0 dists are retrieved

### DIFF
--- a/pqlite/container.py
+++ b/pqlite/container.py
@@ -116,14 +116,16 @@ class CellContainer:
             cell_ids.extend([cell_id] * len(_dists))
             count += len(_dists)
 
-        cell_ids = np.array(cell_ids, dtype=np.int64)
-        dists = np.hstack(dists)
-        doc_idx = np.hstack(doc_idx)
 
-        indices = dists.argsort(axis=0)[:limit]
-        dists = dists[indices]
-        cell_ids = cell_ids[indices]
-        doc_idx = doc_idx[indices]
+        cell_ids = np.array(cell_ids, dtype=np.int64)
+        if len(dists) != 0:
+            dists = np.hstack(dists)
+            doc_idx = np.hstack(doc_idx)
+
+            indices = dists.argsort(axis=0)[:limit]
+            dists = dists[indices]
+            cell_ids = cell_ids[indices]
+            doc_idx = doc_idx[indices]
 
         doc_ids = []
         for cell_id, offset in zip(cell_ids, doc_idx):
@@ -153,6 +155,7 @@ class CellContainer:
                 doc.scores[self.metric.name.lower()].value = dist
                 match_docs.append(doc)
             topk_docs.append(match_docs)
+
 
         return topk_dists, topk_docs
 


### PR DESCRIPTION
The following script in master branch breakes because no example is retrieved in ivf-search and the function call np.hstack(dists) breaks if dists is empty

```python

import pytest
import random
import numpy as np
from jina import Document, DocumentArray
from pqlite import PQLite

N = 1000  # number of data points
Nq = 5
Nt = 2000
D = 128  # dimensionality / number of features


def pqlite_index():
    return index


def pqlite_with_data():
    prices = [10., 25., 50., 100.]
    categories = ['comics', 'movies', 'audiobook']
    columns = [('price', float, True), ('categories', str, True)]
    index = PQLite(dim=D, columns=columns, data_path= 'pqlite_test')

    X = np.random.random((N, D)).astype(
        np.float32
    )  # 10,000 128-dim vectors to be indexed
    docs = [Document(id=f'{i}', embedding=X[i], tags={'prices': np.random.choice(prices),
                                                      'categories': np.random.choice(categories)}) for i in range(N)]
    da = DocumentArray(docs)

    index.index(da)
    return index


pq = pqlite_with_data()
X = np.random.random((Nq, D)).astype(np.float32)
query_da = DocumentArray([Document(embedding=X[i]) for i in range(5)])
conditions = [('price', '>', 200.)]
pq.search(query_da, conditions=conditions)
```