### PR TITLE
perf: make database call batched vs one by one

### DIFF
--- a/executor/benchmark.py
+++ b/executor/benchmark.py
@@ -3,19 +3,33 @@ from jina import DocumentArray
 from jina.logging.profile import TimeContext
 
 n_index = [10_000, 100_000, 500_000, 1_000_000]
+n_index = [10_000]
+
 n_query = [1, 8, 64]
 D = 768
 R = 5
-B = 4096
+B = 4092
+n_cells = 1
+initial_size = int(n_index[0]/10)
 
 from executor import PQLiteIndexer
 
 times = {}
 
 for n_i in n_index:
-    idxer = PQLiteIndexer(dim=D, uses_metas={'workspace': './workspace'})
+
+    idxer = PQLiteIndexer(dim=D,
+                          uses_metas={'workspace': './workspace'},
+                          initial_size=initial_size,
+                          n_cells=n_cells)
+
+
     # build index docs
     i_embs = np.random.random([n_i, D]).astype(np.float32)
+
+    if n_cells > 1:
+        idxer._index.vq_codec.fit(i_embs)
+
     da = DocumentArray.empty(n_i)
     da.embeddings = i_embs
 


### PR DESCRIPTION
One problem current PQLITE is that the write mechanism opens a context manager for every document in docarray. We can improve this by opening a single database path and writting several items.

Current code benchmarked using `executor/benchmark.py` takes quite a long time in individual doc inserts
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   161                                               @profile
   162                                               def insert(
   163                                                   self,
   164                                                   data: np.ndarray,
   165                                                   cells: np.ndarray,
   166                                                   docs: DocumentArray,
   167                                               ):
   168         3         18.0      6.0      0.0          assert len(docs) == len(data)
   169                                           
   170         3          2.0      0.7      0.0          offsets = []
   171     10003     109495.0     10.9      1.3          for doc, cell_id in zip(docs, cells):
   172                                                       # Write-Ahead-Log (WAL)
   173     10000    2738420.0    273.8     32.3              self.doc_store(cell_id).insert([doc])
   174                                           
   175                                                       # update cell_table and meta_table
   176     10000     438633.0     43.9      5.2              offset = self.cell_table(cell_id).insert([doc])[0]
   177     10000     154598.0     15.5      1.8              self._meta_table.add_address(doc.id, cell_id, offset)
   178     10000       7246.0      0.7      0.1              offsets.append(offset)
   179                                           
   180         3        441.0    147.0      0.0          offsets = np.array(offsets, dtype=np.int64)
   181         3    5025522.0 1675174.0     59.3          self._add_vecs(data, cells, offsets)
   182                                           
   183         3        758.0    252.7      0.0          logger.debug(f'=> {len(docs)} new docs added')
```
The results of the `executor/benchmark.py` are
```
|Stored data| Indexing time | Query size=1 | Query size=8 | Query size=64|
|---|---|---|---|---|
|10000 | 7.951 | 0.003 | 0.022 | 0.166|
```

Nevertheless, this PR gets: 
```
|Stored data| Indexing time | Query size=1 | Query size=8 | Query size=64|
|---|---|---|---|---|
|10000 | 5.517 | 0.003 | 0.024 | 0.176|
```

The updated code in the pr spends much less time inserting docs:
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   161                                               @profile
   162                                               def insert(
   163                                                   self,
   164                                                   data: np.ndarray,
   165                                                   cells: np.ndarray,
   166                                                   docs: DocumentArray,
   167                                               ):
   168         3         16.0      5.3      0.0          assert len(docs) == len(data)
   169                                           
   170         3          3.0      1.0      0.0          if self.n_cells == 1:
   171         3     171936.0  57312.0      3.3              self.doc_store(0).insert(docs)
   172         3     216069.0  72023.0      4.2              offsets = self.cell_table(0).insert(docs)
   173                                           
   174                                                       # if we had _meta_table.add_adress(doc_ids, cell_ids, offsets)
   175                                                       # we could probably speedup this part as
   176     10003      69704.0      7.0      1.3              for doc, cell_id, offset in zip(docs, cells, offsets):
   177     10000     113109.0     11.3      2.2                  self._meta_table.add_address(doc.id, cell_id, offset)
   178                                           
   179                                                   else:
   180                                                       for doc, cell_id in zip(docs, cells):
   181                                                           # Write-Ahead-Log (WAL)
   182                                                           self.doc_store(cell_id).insert([doc])
   183                                           
   184                                                       offsets = []
   185                                                       for doc, cell_id in zip(docs, cells):
   186                                                           # Write-Ahead-Log (WAL)
   187                                                           self.doc_store(cell_id).insert([doc])
   188                                                           # update cell_table and meta_table
   189                                                           offset = self.cell_table(cell_id).insert([doc])[0]
   190                                                           self._meta_table.add_address(doc.id, cell_id, offset)
   191                                                           offsets.append(offset)
   192                                           
   193         3        439.0    146.3      0.0          offsets = np.array(offsets, dtype=np.int64)
   194         3    4633868.0 1544622.7     89.0          self._add_vecs(data, cells, offsets)
   195         3        783.0    261.0      0.0          logger.debug(f'=> {len(docs)} new docs added')```