### PR TITLE
feat: add pq support for hnsw searching

### DIFF
--- a/annlite/container.py
+++ b/annlite/container.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from .core.codec.pq import PQCodec
+    from .core.codec.base import BaseTrainedPQ
 
 from .core.index.hnsw import HnswIndex
 from .core.index.pq_index import PQIndex
@@ -30,6 +31,7 @@ class CellContainer:
         serialize_config: Optional[Dict] = None,
         data_path: Path = Path('./data'),
         lock: bool = True,
+        hnsw_using_pq: Optional['BaseTrainedPQ'] = None,
         **kwargs,
     ):
         self.dim = dim
@@ -58,6 +60,7 @@ class CellContainer:
                     initial_size=initial_size,
                     expand_step_size=expand_step_size,
                     expand_mode=expand_mode,
+                    using_pq=hnsw_using_pq,
                     **kwargs,
                 )
                 for _ in range(n_cells)

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -30,7 +30,6 @@ class CellContainer:
         serialize_config: Optional[Dict] = None,
         data_path: Path = Path('./data'),
         lock: bool = True,
-        hnsw_using_pq: Optional['PQCodec'] = None,
         **kwargs,
     ):
         self.dim = dim
@@ -38,32 +37,32 @@ class CellContainer:
         self.n_cells = n_cells
         self.data_path = data_path
 
-        if pq_codec is not None:
-            self._vec_indexes = [
-                PQIndex(
-                    dim,
-                    pq_codec,
-                    metric=metric,
-                    initial_size=initial_size,
-                    expand_step_size=expand_step_size,
-                    expand_mode=expand_mode,
-                    **kwargs,
-                )
-                for _ in range(n_cells)
-            ]
-        else:
-            self._vec_indexes = [
-                HnswIndex(
-                    dim,
-                    metric=metric,
-                    initial_size=initial_size,
-                    expand_step_size=expand_step_size,
-                    expand_mode=expand_mode,
-                    using_pq=hnsw_using_pq,
-                    **kwargs,
-                )
-                for _ in range(n_cells)
-            ]
+        # if pq_codec is not None:
+        #     self._vec_indexes = [
+        #         PQIndex(
+        #             dim,
+        #             pq_codec,
+        #             metric=metric,
+        #             initial_size=initial_size,
+        #             expand_step_size=expand_step_size,
+        #             expand_mode=expand_mode,
+        #             **kwargs,
+        #         )
+        #         for _ in range(n_cells)
+        #     ]
+        # else:
+        self._vec_indexes = [
+            HnswIndex(
+                dim,
+                metric=metric,
+                initial_size=initial_size,
+                expand_step_size=expand_step_size,
+                expand_mode=expand_mode,
+                pq_codec=pq_codec,
+                **kwargs,
+            )
+            for _ in range(n_cells)
+        ]
 
         self._doc_stores = [
             DocStorage(

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -7,7 +7,6 @@ from loguru import logger
 
 if TYPE_CHECKING:  # pragma: no cover
     from .core.codec.pq import PQCodec
-    from .core.codec.base import BaseTrainedPQ
 
 from .core.index.hnsw import HnswIndex
 from .core.index.pq_index import PQIndex
@@ -31,7 +30,7 @@ class CellContainer:
         serialize_config: Optional[Dict] = None,
         data_path: Path = Path('./data'),
         lock: bool = True,
-        hnsw_using_pq: Optional['BaseTrainedPQ'] = None,
+        hnsw_using_pq: Optional['PQCodec'] = None,
         **kwargs,
     ):
         self.dim = dim

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -5,7 +5,7 @@ import numpy as np
 from docarray import Document, DocumentArray
 from loguru import logger
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .core.codec.pq import PQCodec
     from .core.codec.base import BaseTrainedPQ
 

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -6,8 +6,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
     from typing import Tuple
 
-    import numpy as np
-
 
 class BaseCodec(ABC):
     def __init__(self, require_train: bool = True):

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -2,7 +2,7 @@ import pickle
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
     from typing import Tuple
 

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -39,36 +39,3 @@ class BaseCodec(ABC):
 
     def _check_trained(self):
         assert self.is_trained is True, f'{self.__class__.__name__} requires training'
-
-
-class BaseTrainedPQ(ABC):
-    """Interface for a trained PQ.
-    If you want to use the product quantization in HNSW backend, the PQ class you pass should
-    satisfy this interface .
-    """
-
-    @abstractmethod
-    def get_subspace_splitting(self) -> 'Tuple[int]':
-        """Return subspace splitting setting
-
-        :return: tuple of (`n_subvectors`, `n_clusters`, `d_subvector`)
-        """
-        pass
-
-    @abstractmethod
-    def encode(self, x: 'np.ndarray') -> 'np.ndarray':
-        """Quantize `x` into integer arrays
-
-        :param x: Input vectors with shape(`N`, `n_subvectors`*`d_subvector`), and dtype=np.float32.
-        :return: PQ codes with shape=(`N`, `n_subvectors`), integer dtype, each element < `n_clusters`.
-        """
-        pass
-
-    @abstractmethod
-    def get_codebook(self) -> 'np.ndarray':
-        """Return the codebook parameters.
-
-        Expect a 3-dimensional matrix is returned,
-        with shape (`n_subvectors`, `n_clusters`, `d_subvector`) and dtype float32
-        """
-        pass

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -69,6 +69,6 @@ class BaseTrainedPQ(ABC):
         """Return the codebook parameters.
 
         Expect a 3-dimensional matrix is returned,
-        with shape (`n_subvectors`, `n_clusters`, `d_subvector`)
+        with shape (`n_subvectors`, `n_clusters`, `d_subvector`) and dtype float32
         """
         pass

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -48,7 +48,7 @@ class BaseTrainedPQ(ABC):
     """
 
     @abstractmethod
-    def get_subspace_splitting(self) -> Tuple[int]:
+    def get_subspace_splitting(self) -> 'Tuple[int]':
         """Return subspace splitting setting
 
         :return: tuple of (`n_subvectors`, `n_clusters`, `d_subvector`)

--- a/annlite/core/codec/base.py
+++ b/annlite/core/codec/base.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Tuple
+
+    import numpy as np
 
 
 class BaseCodec(ABC):
@@ -36,3 +39,36 @@ class BaseCodec(ABC):
 
     def _check_trained(self):
         assert self.is_trained is True, f'{self.__class__.__name__} requires training'
+
+
+class BaseTrainedPQ(ABC):
+    """Interface for a trained PQ.
+    If you want to use the product quantization in HNSW backend, the PQ class you pass should
+    satisfy this interface .
+    """
+
+    @abstractmethod
+    def get_subspace_splitting(self) -> Tuple[int]:
+        """Return subspace splitting setting
+
+        :return: tuple of (`n_subvectors`, `n_clusters`, `d_subvector`)
+        """
+        pass
+
+    @abstractmethod
+    def encode(self, x: 'np.ndarray') -> 'np.ndarray':
+        """Quantize `x` into integer arrays
+
+        :param x: Input vectors with shape(`N`, `n_subvectors`*`d_subvector`), and dtype=np.float32.
+        :return: PQ codes with shape=(`N`, `n_subvectors`), integer dtype, each element < `n_clusters`.
+        """
+        pass
+
+    @abstractmethod
+    def get_codebook(self) -> 'np.ndarray':
+        """Return the codebook parameters.
+
+        Expect a 3-dimensional matrix is returned,
+        with shape (`n_subvectors`, `n_clusters`, `d_subvector`)
+        """
+        pass

--- a/annlite/core/codec/pq.py
+++ b/annlite/core/codec/pq.py
@@ -4,12 +4,12 @@ from scipy.cluster.vq import vq
 from annlite import pq_bind
 
 from ...enums import Metric
-from .base import BaseCodec
+from .base import BaseCodec, BaseTrainedPQ
 
 # from pqlite.pq_bind import precompute_adc_table, dist_pqcodes_to_codebooks
 
 
-class PQCodec(BaseCodec):
+class PQCodec(BaseCodec, BaseTrainedPQ):
     """Implementation of Product Quantization (PQ) [Jegou11]_.
 
     For the indexing phase of database vectors,
@@ -196,6 +196,15 @@ class PQCodec(BaseCodec):
     @property
     def codebooks(self):
         return self._codebooks
+
+    # trained pq interface ----------------
+    def get_codebook(self) -> 'np.ndarray':
+        return self.codebooks
+
+    def get_subspace_splitting(self):
+        return (self.n_subvectors, self.n_clusters, self.d_subvector)
+
+    # -------------------------------------
 
 
 class DistanceTable(object):

--- a/annlite/core/codec/pq.py
+++ b/annlite/core/codec/pq.py
@@ -4,12 +4,12 @@ from scipy.cluster.vq import vq
 from annlite import pq_bind
 
 from ...enums import Metric
-from .base import BaseCodec, BaseTrainedPQ
+from .base import BaseCodec
 
 # from pqlite.pq_bind import precompute_adc_table, dist_pqcodes_to_codebooks
 
 
-class PQCodec(BaseCodec, BaseTrainedPQ):
+class PQCodec(BaseCodec):
     """Implementation of Product Quantization (PQ) [Jegou11]_.
 
     For the indexing phase of database vectors,
@@ -199,9 +199,18 @@ class PQCodec(BaseCodec, BaseTrainedPQ):
 
     # trained pq interface ----------------
     def get_codebook(self) -> 'np.ndarray':
+        """Return the codebook parameters.
+
+        Expect a 3-dimensional matrix is returned,
+        with shape (`n_subvectors`, `n_clusters`, `d_subvector`) and dtype float32
+        """
         return self.codebooks
 
     def get_subspace_splitting(self):
+        """Return subspace splitting setting
+
+        :return: tuple of (`n_subvectors`, `n_clusters`, `d_subvector`)
+        """
         return (self.n_subvectors, self.n_clusters, self.d_subvector)
 
     # -------------------------------------

--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -47,10 +47,9 @@ class HnswIndex(BaseIndex):
             max_elements=self.capacity,
             ef_construction=self.ef_construction,
             M=self.max_connection,
+            using_pq=self.using_pq,
         )
         self._index.set_ef(self.ef_search)
-        if self.using_pq is not None:
-            self._index.loadPQ(self.using_pq)
 
     def add_with_ids(self, x: 'np.ndarray', ids: List[int]):
         max_id = max(ids) + 1

--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -22,7 +22,7 @@ class HnswIndex(BaseIndex):
         ef_construction: int = 200,
         ef_search: int = 50,
         max_connection: int = 16,
-        using_pq: Optional['BaseCodec'] = None,
+        pq_codec: Optional['BaseCodec'] = None,
         **kwargs,
     ):
         """
@@ -38,7 +38,7 @@ class HnswIndex(BaseIndex):
         self.ef_construction = ef_construction
         self.ef_search = ef_search
         self.max_connection = max_connection
-        self.using_pq = using_pq
+        self.pq_codec = pq_codec
         self._init_hnsw_index()
 
     def _init_hnsw_index(self):
@@ -47,7 +47,7 @@ class HnswIndex(BaseIndex):
             max_elements=self.capacity,
             ef_construction=self.ef_construction,
             M=self.max_connection,
-            using_pq=self.using_pq,
+            using_pq=self.pq_codec,
         )
         self._index.set_ef(self.ef_search)
 

--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -9,7 +9,7 @@ from annlite.hnsw_bind import Index
 from ....enums import Metric
 from ..base import BaseIndex
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ...codec.base import BaseTrainedPQ
 
 

--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -10,7 +10,7 @@ from ....enums import Metric
 from ..base import BaseIndex
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ...codec.base import BaseTrainedPQ
+    from ...codec.base import BaseCodec
 
 
 class HnswIndex(BaseIndex):
@@ -22,7 +22,7 @@ class HnswIndex(BaseIndex):
         ef_construction: int = 200,
         ef_search: int = 50,
         max_connection: int = 16,
-        using_pq: Optional['BaseTrainedPQ'] = None,
+        using_pq: Optional['BaseCodec'] = None,
         **kwargs,
     ):
         """

--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
 from loguru import logger
@@ -8,6 +8,9 @@ from annlite.hnsw_bind import Index
 
 from ....enums import Metric
 from ..base import BaseIndex
+
+if TYPE_CHECKING:
+    from ...codec.base import BaseTrainedPQ
 
 
 class HnswIndex(BaseIndex):
@@ -19,6 +22,7 @@ class HnswIndex(BaseIndex):
         ef_construction: int = 200,
         ef_search: int = 50,
         max_connection: int = 16,
+        using_pq: Optional['BaseTrainedPQ'] = None,
         **kwargs,
     ):
         """
@@ -34,7 +38,7 @@ class HnswIndex(BaseIndex):
         self.ef_construction = ef_construction
         self.ef_search = ef_search
         self.max_connection = max_connection
-
+        self.using_pq = using_pq
         self._init_hnsw_index()
 
     def _init_hnsw_index(self):
@@ -45,6 +49,8 @@ class HnswIndex(BaseIndex):
             M=self.max_connection,
         )
         self._index.set_ef(self.ef_search)
+        if self.using_pq is not None:
+            self._index.loadPQ(self.using_pq)
 
     def add_with_ids(self, x: 'np.ndarray', ids: List[int]):
         max_id = max(ids) + 1

--- a/annlite/core/index/pq_index.py
+++ b/annlite/core/index/pq_index.py
@@ -7,7 +7,8 @@ from ..codec.pq import PQCodec
 from .flat_index import FlatIndex
 
 
-class PQIndex(FlatIndex):
+# PQIndex is no longer used for index backend, hence remove from coverage
+class PQIndex(FlatIndex):  # pragma: no cover
     def __init__(
         self,
         dim: int,

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from docarray import DocumentArray
+    from .core.codec.base import BaseTrainedPQ
 
 from .container import CellContainer
 from .core import PQCodec, VQCodec
@@ -62,6 +63,7 @@ class AnnLite(CellContainer):
         read_only: bool = False,
         verbose: bool = False,
         lock: bool = True,
+        hnsw_using_pq: Optional['BaseTrainedPQ'] = None,
         *args,
         **kwargs,
     ):
@@ -121,6 +123,7 @@ class AnnLite(CellContainer):
             columns=columns,
             data_path=data_path,
             lock=lock,
+            hnsw_using_pq=hnsw_using_pq,
             **kwargs,
         )
 

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -53,6 +53,7 @@ class AnnLite(CellContainer):
         metric: Union[str, Metric] = 'cosine',
         n_cells: int = 1,
         n_subvectors: Optional[int] = None,
+        n_clusters: Optional[int] = 256,
         n_probe: int = 16,
         initial_size: Optional[int] = None,
         expand_step_size: int = 10240,
@@ -73,6 +74,7 @@ class AnnLite(CellContainer):
             ), '"dim" needs to be divisible by "n_subvectors"'
 
         self.n_subvectors = n_subvectors
+        self.n_clusters = n_clusters
         self.n_probe = max(n_probe, n_cells)
         self.n_cells = n_cells
 
@@ -106,9 +108,14 @@ class AnnLite(CellContainer):
             )
             self.pq_codec = PQCodec.load(self._pq_codec_path)
         elif n_subvectors:
-            logger.info(f'Initialize PQ codec (n_subvectors={self.n_subvectors})')
+            logger.info(
+                f'Initialize PQ codec (n_subvectors={self.n_subvectors}, n_clusters={self.n_clusters})'
+            )
             self.pq_codec = PQCodec(
-                dim, n_subvectors=n_subvectors, n_clusters=256, metric=self.metric
+                dim,
+                n_subvectors=self.n_subvectors,
+                n_clusters=self.n_clusters,
+                metric=self.metric,
             )
 
         super(AnnLite, self).__init__(

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -62,7 +62,6 @@ class AnnLite(CellContainer):
         read_only: bool = False,
         verbose: bool = False,
         lock: bool = True,
-        hnsw_using_pq: bool = False,
         *args,
         **kwargs,
     ):
@@ -112,13 +111,6 @@ class AnnLite(CellContainer):
                 dim, n_subvectors=n_subvectors, n_clusters=256, metric=self.metric
             )
 
-        self.hnsw_pq_codec = None
-        if self._hnsw_pq_codec_path.exists() and hnsw_using_pq:
-            self.hnsw_pq_codec = PQCodec.load(self._hnsw_pq_codec_path)
-            logger.info(
-                f'Load trained PQ codec with config {self.hnsw_pq_codec.get_subspace_splitting()} from {self.model_path}'
-            )
-
         super(AnnLite, self).__init__(
             dim=dim,
             metric=metric,
@@ -129,7 +121,6 @@ class AnnLite(CellContainer):
             columns=columns,
             data_path=data_path,
             lock=lock,
-            hnsw_using_pq=self.hnsw_pq_codec,
             **kwargs,
         )
 
@@ -424,8 +415,6 @@ class AnnLite(CellContainer):
             self.vq_codec.dump(self._vq_codec_path)
         if self.pq_codec:
             self.pq_codec.dump(self._pq_codec_path)
-        if self.hnsw_pq_codec:
-            self.hnsw_pq_codec.dump(self._hnsw_pq_codec_path)
 
     def _rebuild_index(self):
         for cell_id in range(self.n_cells):
@@ -461,10 +450,6 @@ class AnnLite(CellContainer):
     @property
     def _pq_codec_path(self):
         return self.model_path / 'pq_codec.bin'
-
-    @property
-    def _hnsw_pq_codec_path(self):
-        return self.model_path / 'hnsw_pq_codec.bin'
 
     @property
     def use_smart_probing(self):

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -6,7 +6,7 @@ import numpy as np
 from docarray.math.ndarray import to_numpy_array
 from loguru import logger
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from docarray import DocumentArray
     from .core.codec.base import BaseTrainedPQ
 

--- a/annlite/math.py
+++ b/annlite/math.py
@@ -2,8 +2,10 @@ from typing import Tuple
 
 import numpy as np
 
+EPS = 1e-30
 
-def cosine(x_mat: 'np.ndarray', y_mat: 'np.ndarray', eps: float = 1e-7) -> 'np.ndarray':
+
+def cosine(x_mat: 'np.ndarray', y_mat: 'np.ndarray', eps: float = EPS) -> 'np.ndarray':
     """Cosine distance between each row in x_mat and each row in y_mat.
 
     :param x_mat: np.ndarray with ndim=2

--- a/annlite/storage/base.py
+++ b/annlite/storage/base.py
@@ -1,7 +1,7 @@
 import abc
 from typing import TYPE_CHECKING, List, Optional
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import numpy as np
 
 from ..enums import ExpandMode

--- a/annlite/storage/table.py
+++ b/annlite/storage/table.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import numpy as np
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from docarray import DocumentArray
 
 sqlite3.register_adapter(np.int64, lambda x: int(x))

--- a/include/hnswlib/hnswlib.h
+++ b/include/hnswlib/hnswlib.h
@@ -101,3 +101,4 @@ AlgorithmInterface<dist_t>::searchKnnCloserFirst(const void *query_data,
 #include "hnswalg.h"
 #include "space_ip.h"
 #include "space_l2.h"
+#include "space_pq.h"

--- a/include/hnswlib/space_pq.h
+++ b/include/hnswlib/space_pq.h
@@ -1,0 +1,84 @@
+#pragma once
+#include "hnswlib.h"
+#include <stdint.h>
+
+namespace hnswlib {
+
+typedef struct pq_dist_param_s {
+  size_t n_subvectors;
+  size_t n_clusters;
+  float *dist_mat;
+} pq_dist_param_t;
+
+template <typename CODETYPE>
+static float PQLookup(const void *pVect1v, const void *pVect2v,
+                      const void *qty_ptr) {
+  CODETYPE *pVect1 = (CODETYPE *)pVect1v;
+  CODETYPE *pVect2 = (CODETYPE *)pVect2v;
+  pq_dist_param_t *qty = (pq_dist_param_t *)qty_ptr;
+  size_t subspace_mat_size = (qty->n_clusters) * (qty->n_clusters);
+  size_t n_clusters = qty->n_clusters;
+  float res = 0;
+
+  for (size_t i = 0; i < qty->n_subvectors; i++) {
+    res += qty->dist_mat[i * subspace_mat_size + (*pVect1) * n_clusters +
+                         (*pVect2)];
+    pVect1++;
+    pVect2++;
+  }
+  return (res);
+}
+
+template <typename CODETYPE> class PQ_L2Space : public SpaceInterface<float> {
+  DISTFUNC<float> fstdistfunc_;
+  size_t data_size_, d_subvectors;
+  pq_dist_param_t param;
+  float *codebook;
+
+public:
+  PQ_L2Space(size_t n_subvectors, size_t n_clusters, size_t d_subvectors,
+             float *codebook) {
+    param.n_subvectors = n_subvectors;
+    param.n_clusters = n_clusters;
+    this->codebook = codebook;
+    this->d_subvectors = d_subvectors;
+    data_size_ = n_subvectors * sizeof(CODETYPE);
+    compute_dist_mat();
+    printf("%f, %f, %f\n", param.dist_mat[0], param.dist_mat[1],
+           param.dist_mat[2]);
+    fstdistfunc_ = PQLookup<CODETYPE>;
+  }
+
+  void compute_dist_mat() {
+    param.dist_mat = (float *)malloc(param.n_subvectors * param.n_clusters *
+                                     param.n_clusters * sizeof(float));
+    size_t subspace_mat_size = param.n_clusters * param.n_clusters;
+    size_t subspace_size = param.n_clusters * d_subvectors;
+    for (size_t i = 0; i < param.n_subvectors; i++) {
+      for (size_t j = 0; j < param.n_clusters; j++) {
+        param.dist_mat[i * subspace_mat_size + j * param.n_clusters] = 0;
+        for (size_t k = j + 1; k < param.n_clusters; k++) {
+          float dist = 0;
+          float temp;
+          for (size_t d = 0; d < d_subvectors; d++) {
+            temp = (codebook[i * subspace_size + j * d_subvectors + d] -
+                    codebook[i * subspace_size + k * d_subvectors + d]);
+            dist += temp * temp;
+          }
+          param.dist_mat[i * subspace_mat_size + j * param.n_clusters + k] =
+              dist;
+          param.dist_mat[i * subspace_mat_size + k * param.n_clusters + j] =
+              dist;
+        }
+      }
+    }
+  }
+  size_t get_data_size() { return data_size_; }
+
+  DISTFUNC<float> get_dist_func() { return fstdistfunc_; }
+
+  void *get_dist_func_param() { return &param; }
+
+  ~PQ_L2Space() { free(param.dist_mat); }
+};
+} // namespace hnswlib

--- a/include/hnswlib/space_pq.h
+++ b/include/hnswlib/space_pq.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "hnswlib.h"
+#include <memory>
 #include <stdint.h>
 
 namespace hnswlib {
@@ -33,13 +34,13 @@ template <typename CODETYPE> class PQ_L2Space : public SpaceInterface<float> {
   DISTFUNC<float> fstdistfunc_;
   size_t data_size_, d_subvectors;
   pq_dist_param_t param;
-  float *codebook;
+  std::shared_ptr<float *> codebook;
 
 public:
   PQ_L2Space(size_t n_subvectors, size_t n_clusters, size_t d_subvectors,
-             float *codebook) {
-    param.n_subvectors = n_subvectors;
-    param.n_clusters = n_clusters;
+             std::shared_ptr<float *> codebook) {
+    this->param.n_subvectors = n_subvectors;
+    this->param.n_clusters = n_clusters;
     this->codebook = codebook;
     this->d_subvectors = d_subvectors;
     data_size_ = n_subvectors * sizeof(CODETYPE);
@@ -59,8 +60,9 @@ public:
           float dist = 0;
           float temp;
           for (size_t d = 0; d < d_subvectors; d++) {
-            temp = (codebook[i * subspace_size + j * d_subvectors + d] -
-                    codebook[i * subspace_size + k * d_subvectors + d]);
+            temp =
+                ((codebook.get() + (i * subspace_size + j * d_subvectors + d)) -
+                 (codebook.get() + (i * subspace_size + k * d_subvectors + d)));
             dist += temp * temp;
           }
           param.dist_mat[i * subspace_mat_size + j * param.n_clusters + k] =

--- a/include/hnswlib/space_pq.h
+++ b/include/hnswlib/space_pq.h
@@ -77,12 +77,11 @@ template <typename CODETYPE> class PQ_Space : public SpaceInterface<float> {
   size_t data_size_, d_subvectors;
   pq_dist_param_t param;
   bool ip_enable, normalize;
-  float *codebook;
 
 public:
   PQ_Space(const std::string &space_name, size_t n_subvectors,
            size_t n_clusters, size_t d_subvectors, float *codebook)
-      : codebook(codebook), d_subvectors(d_subvectors) {
+      : d_subvectors(d_subvectors) {
     param.n_subvectors = n_subvectors;
     param.n_clusters = n_clusters;
     data_size_ = n_subvectors * sizeof(CODETYPE);
@@ -99,10 +98,10 @@ public:
       normalize = true;
       fstdistfunc_ = PQLookup_Cosine<CODETYPE>;
     }
-    compute_mats();
+    compute_mats(codebook);
   }
 
-  void compute_mats() {
+  void compute_mats(float *codebook) {
     param.dist_mat = (float *)malloc(param.n_subvectors * param.n_clusters *
                                      param.n_clusters * sizeof(float));
     if (normalize) {
@@ -151,9 +150,6 @@ public:
 
   void *get_dist_func_param() { return &param; }
 
-  ~PQ_Space() {
-    free(param.dist_mat);
-    this->codebook = nullptr;
-  }
+  ~PQ_Space() { free(param.dist_mat); }
 };
 } // namespace hnswlib

--- a/include/hnswlib/space_pq.h
+++ b/include/hnswlib/space_pq.h
@@ -44,8 +44,6 @@ public:
     this->d_subvectors = d_subvectors;
     data_size_ = n_subvectors * sizeof(CODETYPE);
     compute_dist_mat();
-    printf("%f, %f, %f\n", param.dist_mat[0], param.dist_mat[1],
-           param.dist_mat[2]);
     fstdistfunc_ = PQLookup<CODETYPE>;
   }
 

--- a/include/hnswlib/space_pq.h
+++ b/include/hnswlib/space_pq.h
@@ -1,19 +1,42 @@
 #pragma once
 #include "hnswlib.h"
+#include <math.h>
 #include <memory>
 #include <stdint.h>
-
 namespace hnswlib {
 
 typedef struct pq_dist_param_s {
   size_t n_subvectors;
   size_t n_clusters;
   float *dist_mat;
+  float *norm_mat;
 } pq_dist_param_t;
 
 template <typename CODETYPE>
-static float PQLookup(const void *pVect1v, const void *pVect2v,
-                      const void *qty_ptr) {
+static float PQLookup_Cosine(const void *pVect1v, const void *pVect2v,
+                             const void *qty_ptr) {
+  CODETYPE *pVect1 = (CODETYPE *)pVect1v;
+  CODETYPE *pVect2 = (CODETYPE *)pVect2v;
+  pq_dist_param_t *qty = (pq_dist_param_t *)qty_ptr;
+  size_t subspace_mat_size = (qty->n_clusters) * (qty->n_clusters);
+  size_t n_clusters = qty->n_clusters;
+  float res = 0, norm_1v = 0, norm_2v = 0;
+
+  for (size_t i = 0; i < qty->n_subvectors; i++) {
+    res += qty->dist_mat[i * subspace_mat_size + (*pVect1) * n_clusters +
+                         (*pVect2)];
+    norm_1v += qty->norm_mat[i * n_clusters + (*pVect1)];
+    norm_2v += qty->norm_mat[i * n_clusters + (*pVect2)];
+    pVect1++;
+    pVect2++;
+  }
+  res = (res / (sqrt(norm_1v) * sqrt(norm_2v)));
+  return (1.0f - res);
+}
+
+template <typename CODETYPE>
+static float PQLookup_IP(const void *pVect1v, const void *pVect2v,
+                         const void *qty_ptr) {
   CODETYPE *pVect1 = (CODETYPE *)pVect1v;
   CODETYPE *pVect2 = (CODETYPE *)pVect2v;
   pq_dist_param_t *qty = (pq_dist_param_t *)qty_ptr;
@@ -27,43 +50,92 @@ static float PQLookup(const void *pVect1v, const void *pVect2v,
     pVect1++;
     pVect2++;
   }
-  return (res);
+  return (1.0f - res);
 }
 
-template <typename CODETYPE> class PQ_L2Space : public SpaceInterface<float> {
+template <typename CODETYPE>
+static float PQLookup_L2(const void *pVect1v, const void *pVect2v,
+                         const void *qty_ptr) {
+  CODETYPE *pVect1 = (CODETYPE *)pVect1v;
+  CODETYPE *pVect2 = (CODETYPE *)pVect2v;
+  pq_dist_param_t *qty = (pq_dist_param_t *)qty_ptr;
+  size_t subspace_mat_size = (qty->n_clusters) * (qty->n_clusters);
+  size_t n_clusters = qty->n_clusters;
+  float res = 0;
+
+  for (size_t i = 0; i < qty->n_subvectors; i++) {
+    res += qty->dist_mat[i * subspace_mat_size + (*pVect1) * n_clusters +
+                         (*pVect2)];
+    pVect1++;
+    pVect2++;
+  }
+  return res;
+}
+
+template <typename CODETYPE> class PQ_Space : public SpaceInterface<float> {
   DISTFUNC<float> fstdistfunc_;
   size_t data_size_, d_subvectors;
   pq_dist_param_t param;
-  std::shared_ptr<float *> codebook;
+  bool ip_enable, normalize;
+  float *codebook;
 
 public:
-  PQ_L2Space(size_t n_subvectors, size_t n_clusters, size_t d_subvectors,
-             std::shared_ptr<float *> codebook) {
-    this->param.n_subvectors = n_subvectors;
-    this->param.n_clusters = n_clusters;
-    this->codebook = codebook;
-    this->d_subvectors = d_subvectors;
+  PQ_Space(const std::string &space_name, size_t n_subvectors,
+           size_t n_clusters, size_t d_subvectors, float *codebook)
+      : codebook(codebook), d_subvectors(d_subvectors) {
+    param.n_subvectors = n_subvectors;
+    param.n_clusters = n_clusters;
     data_size_ = n_subvectors * sizeof(CODETYPE);
-    compute_dist_mat();
-    fstdistfunc_ = PQLookup<CODETYPE>;
+    if (space_name == "l2") {
+      ip_enable = false;
+      normalize = false;
+      fstdistfunc_ = PQLookup_L2<CODETYPE>;
+    } else if (space_name == "ip") {
+      ip_enable = true;
+      normalize = false;
+      fstdistfunc_ = PQLookup_IP<CODETYPE>;
+    } else if (space_name == "cosine") {
+      ip_enable = true;
+      normalize = true;
+      fstdistfunc_ = PQLookup_Cosine<CODETYPE>;
+    }
+    compute_mats();
   }
 
-  void compute_dist_mat() {
+  void compute_mats() {
     param.dist_mat = (float *)malloc(param.n_subvectors * param.n_clusters *
                                      param.n_clusters * sizeof(float));
+    if (normalize) {
+      param.norm_mat = (float *)malloc(param.n_subvectors * param.n_clusters *
+                                       sizeof(float));
+    }
     size_t subspace_mat_size = param.n_clusters * param.n_clusters;
     size_t subspace_size = param.n_clusters * d_subvectors;
     for (size_t i = 0; i < param.n_subvectors; i++) {
       for (size_t j = 0; j < param.n_clusters; j++) {
-        param.dist_mat[i * subspace_mat_size + j * param.n_clusters] = 0;
-        for (size_t k = j + 1; k < param.n_clusters; k++) {
-          float dist = 0;
+        if (normalize) {
+          float cluster_norm = 1e-30;
           float temp;
           for (size_t d = 0; d < d_subvectors; d++) {
-            temp =
-                ((codebook.get() + (i * subspace_size + j * d_subvectors + d)) -
-                 (codebook.get() + (i * subspace_size + k * d_subvectors + d)));
-            dist += temp * temp;
+            temp = codebook[i * subspace_size + j * d_subvectors + d];
+            cluster_norm += temp * temp;
+          }
+          param.norm_mat[i * param.n_clusters + j] = cluster_norm;
+        }
+        for (size_t k = j; k < param.n_clusters; k++) {
+          float dist = 0;
+          if (ip_enable) {
+            for (size_t d = 0; d < d_subvectors; d++) {
+              dist += (codebook[i * subspace_size + j * d_subvectors + d] *
+                       codebook[i * subspace_size + k * d_subvectors + d]);
+            }
+          } else {
+            float temp;
+            for (size_t d = 0; d < d_subvectors; d++) {
+              temp = (codebook[i * subspace_size + j * d_subvectors + d] -
+                      codebook[i * subspace_size + k * d_subvectors + d]);
+              dist += temp * temp;
+            }
           }
           param.dist_mat[i * subspace_mat_size + j * param.n_clusters + k] =
               dist;
@@ -79,6 +151,9 @@ public:
 
   void *get_dist_func_param() { return &param; }
 
-  ~PQ_L2Space() { free(param.dist_mat); }
+  ~PQ_Space() {
+    free(param.dist_mat);
+    this->codebook = nullptr;
+  }
 };
 } // namespace hnswlib

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,8 @@
+import enum
 import operator
 import random
 from collections import namedtuple
+from distutils.command.build import build
 from pathlib import Path
 
 import numpy as np
@@ -41,6 +43,17 @@ def vanilla_annlite_hash():
     metric_name = 'COSINE'
     key = f'{n_cells} x {n_subvectors} x {metric_name}'
     return hashlib.md5(key.encode()).hexdigest()
+
+
+@pytest.fixture
+def random_docs():
+    X = np.random.random((N, D)).astype(
+        np.float32
+    )  # 10,000 128-dim vectors to be indexed
+    docs = DocumentArray(
+        [Document(id=f'{i}', embedding=X[i], tags={'x': str(i)}) for i in range(N)]
+    )
+    return docs
 
 
 @pytest.fixture
@@ -280,24 +293,22 @@ def test_search_numpy_membership_filter(
         )
 
 
-def test_annlite_hnsw_pq_init(tmpdir, vanilla_annlite_hash):
-    columns = [('x', str)]
-    no_pq_index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
-
-    X = np.random.random((N, D)).astype(
-        np.float32
-    )  # 10,000 128-dim vectors to be indexed
-    docs = DocumentArray(
-        [Document(id=f'{i}', embedding=X[i], tags={'x': str(i)}) for i in range(N)]
+def test_annlite_hnsw_pq_load_empty(tmpdir, random_docs):
+    pq_index = AnnLite(
+        dim=D,
+        data_path=tmpdir / 'annlite_pq_test',
+        n_subvectors=n_subvectors,
     )
-    docs_mock = DocumentArray(
-        [
-            Document(id=f'{i}', embedding=X[i], tags={'x': str(i) + '-'})
-            for i in range(N)
-        ]
-    )
-    no_pq_index.index(docs)
+    with pytest.raises(RuntimeError):
+        # unable to add or search before a actual training of PQ
+        pq_index.index(random_docs)
+    with pytest.raises(RuntimeError):
+        # unable to add or search before a actual training of PQ
+        pq_index.search(random_docs)
 
+
+def test_annlite_hnsw_pq_load_recover(tmpdir, random_docs, vanilla_annlite_hash):
+    X = random_docs.embeddings
     # building PQ from X
     build_pq_codec = PQCodec(dim=D, n_subvectors=n_subvectors, n_clusters=n_clusters)
     build_pq_codec.fit(X)
@@ -308,14 +319,119 @@ def test_annlite_hnsw_pq_init(tmpdir, vanilla_annlite_hash):
         pq_dump_path.mkdir(parents=True, exist_ok=True)
     build_pq_codec.dump(pq_dump_path / 'pq_codec.bin')
 
-    # TODO: pq_codec can only be loaded at init
+    pq_index = AnnLite(
+        dim=D,
+        data_path=tmpdir / 'annlite_pq_test',
+        n_subvectors=n_subvectors,
+    )
+    assert all([x._index.pq_enable for x in pq_index._vec_indexes])
+
+
+def test_annlite_hnsw_pq_load(tmpdir, random_docs):
+    pq_index = AnnLite(
+        dim=D,
+        data_path=tmpdir / 'annlite_pq_test',
+        n_subvectors=n_subvectors,
+    )
+    pq_index.train(random_docs.embeddings)
+    pq_index.index(random_docs)
+    assert all([x.pq_codec.is_trained for x in pq_index._vec_indexes])
+    assert all([x._index.pq_enable for x in pq_index._vec_indexes])
+
+
+def test_annlite_hnsw_pq_search_multi_clusters(tmpdir, random_docs):
+    test_n_clusters = [256, 512, 768]
+    columns = [('x', str)]
+    total_test = 10
+    topk = 50
+
+    X = random_docs.embeddings
+    no_pq_index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+
+    query = DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
+    test_queries = [
+        DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
+        for _ in test_n_clusters
+    ]
+
+    no_pq_index.index(random_docs)
+    no_pq_index.search(query, limit=topk)
+    # ------------------
+    precisions = []
+    for index, test_n_cluster in enumerate(test_n_clusters):
+        pq_index_in = AnnLite(
+            dim=D,
+            columns=columns,
+            data_path=tmpdir / f'annlite_pq_test_{index}',
+            n_subvectors=n_subvectors,
+            n_clusters=test_n_cluster,
+        )
+        pq_index_in.train(X)
+        pq_index_in.index(random_docs)
+        pq_index_in.search(test_queries[index], limit=topk)
+
+        precision = []
+        for i in range(total_test):
+            ground_truth = set([i.tags['x'] for i in query[i].matches])
+            pq_result = set([i.tags['x'] for i in test_queries[index][i].matches])
+            precision.append(len(ground_truth.intersection(pq_result)) / topk)
+        precisions.append(np.mean(precision))
+    for i in range(len(precisions) - 1):
+        assert precisions[i] < precisions[i + 1]
+
+
+@pytest.mark.parametrize('test_n_cluster', [256])
+def test_annlite_hnsw_pq_search_recover(tmpdir, random_docs, test_n_cluster):
+    columns = [('x', str)]
+    total_test = 10
+    topk = 50
+
+    X = random_docs.embeddings
+    no_pq_index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+
+    query = DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
+    query_pq = DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
+    query_pq_trained = DocumentArray(
+        [Document(embedding=X[i]) for i in range(total_test)]
+    )
+
+    no_pq_index.index(random_docs)
+    no_pq_index.search(query, limit=topk)
+    # ------------------
+    pq_index_in = AnnLite(
+        dim=D,
+        columns=columns,
+        data_path=tmpdir / 'annlite_pq_test',
+        n_subvectors=n_subvectors,
+        n_clusters=test_n_cluster,
+    )
+    pq_index_in.train(X)
+    pq_index_in.index(random_docs)
+    pq_index_in.search(query_pq_trained, limit=topk)
+
+    precision = []
+    for i in range(total_test):
+        ground_truth = set([i.tags['x'] for i in query[i].matches])
+        pq_result = set([i.tags['x'] for i in query_pq_trained[i].matches])
+        precision.append(len(ground_truth.intersection(pq_result)) / topk)
+
+    # ------------------
     pq_index = AnnLite(
         dim=D,
         columns=columns,
         data_path=tmpdir / 'annlite_pq_test',
         n_subvectors=n_subvectors,
     )
-    # pq_index.train(X)
 
     assert all([x._index.pq_enable for x in pq_index._vec_indexes])
-    pq_index.index(docs_mock)
+    pq_index.search(query_pq, limit=topk)
+
+    precision_recover = []
+    for i in range(total_test):
+        ground_truth = set([i.tags['x'] for i in query[i].matches])
+        pq_result = set([i.tags['x'] for i in query_pq[i].matches])
+        precision_recover.append(len(ground_truth.intersection(pq_result)) / topk)
+
+    assert abs(np.mean(precision) - np.mean(precision_recover)) < 0.1 * np.mean(
+        precision
+    )


### PR DESCRIPTION
In order to reduce the memory usage of HNSW, we can store the embedding quantized by PQ(normally will be `uint8_t`). Also, the distance computation will become a look-up operation, which should be a little bit faster while adding and searching.