### PR TITLE
fix: proto version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 cython
-docarray>=0.3.16
+docarray>=0.13.16
 lmdb
 loguru
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click
 cython
 docarray>=0.13.16
+docarray[common]>=0.13.16
 lmdb
 loguru
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 click
 cython
-docarray>=0.4.4
+docarray>=0.3.16
 lmdb
 loguru
 numpy
-protobuf>=3.13.0,<=3.20.1
 scikit-learn


### PR DESCRIPTION
remove the protobuf version bump, since it has been included in `docarray>=0.13.16`