### PR TITLE
Feat task queue

### DIFF
--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -20,7 +20,7 @@ class AnnLiteIndexer(Executor):
     def __init__(
         self,
         dim: int = 0,
-        data_path: str = None,
+        data_path: str = './workspace',
         metric: str = 'cosine',
         limit: int = 10,
         ef_construction: int = 200,
@@ -152,7 +152,7 @@ class AnnLiteIndexer(Executor):
         """
         if len(self._task_queue) > 0:
             self.logger.info(
-                'updateing operation is not allowed when len(task queue) > 0'
+                'updating operation is not allowed when len(task queue) > 0'
             )
             return
 
@@ -180,7 +180,7 @@ class AnnLiteIndexer(Executor):
         """
         if len(self._task_queue) > 0:
             self.logger.info(
-                'updateing operation is not allowed when len(task queue) > 0'
+                'deleting operation is not allowed when len(task queue) > 0'
             )
             return
 

--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -20,7 +20,6 @@ class AnnLiteIndexer(Executor):
     def __init__(
         self,
         dim: int = 0,
-        data_path: Optional[str] = None,
         metric: str = 'cosine',
         limit: int = 10,
         ef_construction: int = 200,
@@ -31,6 +30,7 @@ class AnnLiteIndexer(Executor):
         search_traversal_paths: str = '@r',
         columns: Optional[List[Tuple[str, str]]] = None,
         serialize_config: Optional[Dict] = None,
+        data_path: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -50,6 +50,7 @@ class AnnLiteIndexer(Executor):
         :param columns: List of tuples of the form (column_name, str_type). Here str_type must be a string that can be
                 parsed as a valid Python type.
         :param serialize_config: The configurations used for serializing documents, e.g., {'protocol': 'pickle'}
+        :param data_path: location of directory to store the database.
         """
         super().__init__(*args, **kwargs)
         self.logger = JinaLogger(self.__class__.__name__)
@@ -64,7 +65,7 @@ class AnnLiteIndexer(Executor):
         self._valid_input_columns = ['str', 'float', 'int']
         self._data_buffer = DocumentArray()
         self._index_batch_size = 1024
-        self._max_length_queue = 2048
+        self._max_length_queue = 2 * self._index_batch_size
 
         self.logger = JinaLogger(getattr(self.metas, 'name', self.__class__.__name__))
 

--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -67,7 +67,7 @@ class AnnLiteIndexer(Executor):
         self._data_buffer = DocumentArray()
         self._index_batch_size = 1024
         self._max_length_queue = 2 * self._index_batch_size
-        self.lock = threading.Lock()
+        self._index_lock = threading.Lock()
 
         self.logger = JinaLogger(getattr(self.metas, 'name', self.__class__.__name__))
 
@@ -116,7 +116,7 @@ class AnnLiteIndexer(Executor):
         while len(self._data_buffer) >= self._max_length_queue:
             time.sleep(0.01)
 
-        with self.lock:
+        with self._index_lock:
             self._data_buffer.extend(flat_docs)
 
     def _start_index(self):
@@ -129,7 +129,7 @@ class AnnLiteIndexer(Executor):
             while True:
                 if len(self._data_buffer) == 0:
                     continue
-                with self.lock:
+                with self._index_lock:
                     batch_docs = self._data_buffer.pop(
                         range(
                             self._index_batch_size

--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -1,4 +1,3 @@
-import threading
 import time
 import traceback
 from threading import Thread


### PR DESCRIPTION
We noticed that the indexing process is really slow in real use cases because we limit the max `batch_size` in the encoder for free users. The reason is that when the `batch_size` is really small(like 8 or even 1), the indexer only uses the single core of the CPU while for big `batch_size` multi-core CPUs are used. So we don't release the power of multi-cores CPUs in small batch cases.
There are two possible solutions:
1. Create a task queue(like a `DocumentArray`) and gather data from the client and use another thread to do index operation. 
2. Modify the mechanism of how data is distributed through different cores.

In this pr, I implemented solution 1.