### PR TITLE
feat: support load and save hnsw

### DIFF
--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -15,12 +15,12 @@ class HnswIndex(BaseIndex):
     def __init__(
         self,
         dim: int,
-        path_to_load: Optional[str] = None,
         dtype: np.dtype = np.float32,
         metric: Metric = Metric.COSINE,
         ef_construction: int = 200,
         ef_search: int = 50,
         max_connection: int = 16,
+        path_to_load: Optional[str] = None,
         **kwargs,
     ):
         """

--- a/tests/test_hnsw_load_save.py
+++ b/tests/test_hnsw_load_save.py
@@ -1,0 +1,44 @@
+import os
+
+import numpy as np
+import pytest
+
+from annlite.core.index.hnsw import HnswIndex
+
+n_examples = 2000
+n_features = 512
+
+
+@pytest.fixture
+def build_data():
+    Xt = np.random.random((n_examples, n_features)).astype(np.float32)
+    return Xt
+
+
+@pytest.fixture
+def build_hnsw(build_data):
+    Xt = build_data
+    hnsw = HnswIndex(dim=512)
+    hnsw.add_with_ids(x=Xt, ids=list(range(len(Xt))))
+    return hnsw
+
+
+def test_save(tmpdir, build_hnsw):
+    hnsw = build_hnsw
+    hnsw.save_index(os.path.join(tmpdir, 'hnsw.pkl'))
+
+    assert os.path.exists(os.path.join(tmpdir, 'hnsw.pkl')) == True
+
+
+def test_load(tmpdir, build_hnsw):
+    hnsw = build_hnsw
+    hnsw.save_index(os.path.join(tmpdir, 'hnsw.pkl'))
+
+    hnsw_ = HnswIndex(dim=512, path_to_load=os.path.join(tmpdir, 'hnsw.pkl'))
+    assert hnsw_.size == hnsw.size
+
+
+def test_loading_from_wrong_path(tmpdir):
+    hnsw_wrong = HnswIndex(dim=512, path_to_load=os.path.join(tmpdir, 'hnsw_wrong.pkl'))
+
+    assert hnsw_wrong.size == 0

--- a/tests/test_hnsw_load_save.py
+++ b/tests/test_hnsw_load_save.py
@@ -5,8 +5,8 @@ import pytest
 
 from annlite.core.index.hnsw import HnswIndex
 
-n_examples = 2000
-n_features = 512
+n_examples = 100
+n_features = 10
 
 
 @pytest.fixture
@@ -18,27 +18,20 @@ def build_data():
 @pytest.fixture
 def build_hnsw(build_data):
     Xt = build_data
-    hnsw = HnswIndex(dim=512)
+    hnsw = HnswIndex(dim=n_features)
     hnsw.add_with_ids(x=Xt, ids=list(range(len(Xt))))
     return hnsw
 
 
-def test_save(tmpdir, build_hnsw):
+def test_save_and_load(tmpdir, build_hnsw):
     hnsw = build_hnsw
     hnsw.save_index(os.path.join(tmpdir, 'hnsw.pkl'))
+    assert os.path.exists(os.path.join(tmpdir, 'hnsw.pkl')) is True
 
-    assert os.path.exists(os.path.join(tmpdir, 'hnsw.pkl')) == True
-
-
-def test_load(tmpdir, build_hnsw):
-    hnsw = build_hnsw
-    hnsw.save_index(os.path.join(tmpdir, 'hnsw.pkl'))
-
-    hnsw_ = HnswIndex(dim=512, path_to_load=os.path.join(tmpdir, 'hnsw.pkl'))
+    hnsw_ = HnswIndex(dim=n_features, index_file=os.path.join(tmpdir, 'hnsw.pkl'))
     assert hnsw_.size == hnsw.size
 
 
 def test_loading_from_wrong_path(tmpdir):
-    hnsw_wrong = HnswIndex(dim=512, path_to_load=os.path.join(tmpdir, 'hnsw_wrong.pkl'))
-
-    assert hnsw_wrong.size == 0
+    with pytest.raises(FileNotFoundError):
+        HnswIndex(dim=n_features, index_file=os.path.join(tmpdir, 'hnsw_wrong.pkl'))


### PR DESCRIPTION
This pr related to this [issue](https://github.com/jina-ai/annlite/issues/132).

Implemented two APIs inside HNSW: `load_index()` and `save_index()`. In this way we can load the HNSW faster than rebuilding the whole graph