### PR TITLE
fix: fix np.int64 issue

### DIFF
--- a/annlite/core/index/hnsw/index.py
+++ b/annlite/core/index/hnsw/index.py
@@ -22,6 +22,8 @@ def pre_process(f):
     def pre_processed(self: 'HnswIndex', x: np.ndarray, *args, **kwargs):
         if x.ndim == 1:
             x = x.reshape((1, -1))
+        if x.dtype != self.dtype:
+            x = x.astype(self.dtype)
 
         if self.normalization_enable:
             x = l2_normalize(x)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -102,6 +102,14 @@ def test_index(annlite_index):
     annlite_index.index(docs)
 
 
+@pytest.mark.parametrize('dtype', [np.int64, np.float32, np.float64])
+def test_dtype(annlite_index, dtype):
+    X = np.random.random((N, D)).astype(dtype)  # 10,000 128-dim vectors to be indexed
+
+    docs = DocumentArray([Document(id=f'{i}', embedding=X[i]) for i in range(N)])
+    annlite_index.index(docs)
+
+
 def test_delete(annlite_with_data):
     annlite_with_data.delete(['0', '1'])
 


### PR DESCRIPTION
We add l2 normalization in HNSW before index and search, but this will break when the input type is `np.int64`. This pr fix this issue.