### PR TITLE
test: add docarray tests

### DIFF
--- a/annlite/container.py
+++ b/annlite/container.py
@@ -301,8 +301,8 @@ class CellContainer:
         data: 'np.ndarray',
         cells: 'np.ndarray',
         docs: 'DocumentArray',
-        raise_errors_on_not_found: bool = False,
         insert_if_not_found: bool = True,
+        raise_errors_on_not_found: bool = False,
     ):
         update_success = 0
 
@@ -322,7 +322,6 @@ class CellContainer:
                 self.doc_store(cell_id).update([doc])
                 self.meta_table.add_address(doc.id, cell_id, _offset)
                 update_success += 1
-
             elif _cell_id is None:
                 if raise_errors_on_not_found and not insert_if_not_found:
                     raise Exception(

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -281,6 +281,7 @@ class AnnLite(CellContainer):
     ):
         """Update existing documents.
 
+        :param insert_if_not_found: whether to raise error when updated id is not found.
         :param raise_errors_on_not_found: whether to raise exception when id not found.
         :param docs: the document array to be updated.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,24 @@ def update_docs():
             Document(id='doc1', embedding=np.array([0, 0, 0, 1])),
         ]
     )
+
+
+@pytest.fixture(scope='module')
+def start_storage():
+    import os
+
+    os.system(
+        f'docker-compose -f {compose_yml} --project-directory . up  --build -d '
+        f'--remove-orphans'
+    )
+    from elasticsearch import Elasticsearch
+
+    es = Elasticsearch(hosts='http://localhost:9200/')
+    while not es.ping():
+        time.sleep(0.5)
+
+    yield
+    os.system(
+        f'docker-compose -f {compose_yml} --project-directory . down '
+        f'--remove-orphans'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,24 +24,3 @@ def update_docs():
             Document(id='doc1', embedding=np.array([0, 0, 0, 1])),
         ]
     )
-
-
-@pytest.fixture(scope='module')
-def start_storage():
-    import os
-
-    os.system(
-        f'docker-compose -f {compose_yml} --project-directory . up  --build -d '
-        f'--remove-orphans'
-    )
-    from elasticsearch import Elasticsearch
-
-    es = Elasticsearch(hosts='http://localhost:9200/')
-    while not es.ping():
-        time.sleep(0.5)
-
-    yield
-    os.system(
-        f'docker-compose -f {compose_yml} --project-directory . down '
-        f'--remove-orphans'
-    )

--- a/tests/docarray/test_add.py
+++ b/tests/docarray/test_add.py
@@ -1,0 +1,53 @@
+import pytest
+from docarray import Document, DocumentArray
+
+
+def test_add():
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    annlite_doc.extend(
+        [
+            Document(id='r0', embedding=[0, 0, 0]),
+            Document(id='r1', embedding=[1, 1, 1]),
+            Document(id='r2', embedding=[2, 2, 2]),
+            Document(id='r3', embedding=[3, 3, 3]),
+            Document(id='r4', embedding=[4, 4, 4]),
+        ]
+    )
+
+    assert len(annlite_doc) == len(annlite_doc[:, 'embedding'])
+    assert len(annlite_doc[:, 'embedding']) == 5
+
+
+def test_add_conflict_id():
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    annlite_doc.extend(
+        [
+            Document(id='r0', embedding=[0, 0, 0]),
+            Document(id='r1', embedding=[1, 1, 1]),
+            Document(id='r2', embedding=[2, 2, 2]),
+            Document(id='r3', embedding=[3, 3, 3]),
+            Document(id='r4', embedding=[4, 4, 4]),
+        ]
+    )
+
+    from sqlite3 import IntegrityError
+
+    with pytest.raises(IntegrityError):
+        annlite_doc.extend(
+            [
+                Document(id='r0', embedding=[0, 0, 0]),
+                Document(id='r1', embedding=[1, 1, 1]),
+            ]
+        )

--- a/tests/docarray/test_add.py
+++ b/tests/docarray/test_add.py
@@ -1,53 +1,32 @@
 import pytest
-from docarray import Document, DocumentArray
+from docarray import DocumentArray
 
 
-def test_add():
+def test_add(docs):
     annlite_doc = DocumentArray(
         storage='annlite',
         config={
-            'n_dim': 3,
+            'n_dim': 4,
         },
     )
 
-    annlite_doc.extend(
-        [
-            Document(id='r0', embedding=[0, 0, 0]),
-            Document(id='r1', embedding=[1, 1, 1]),
-            Document(id='r2', embedding=[2, 2, 2]),
-            Document(id='r3', embedding=[3, 3, 3]),
-            Document(id='r4', embedding=[4, 4, 4]),
-        ]
-    )
+    annlite_doc.extend(docs)
 
     assert len(annlite_doc) == len(annlite_doc[:, 'embedding'])
-    assert len(annlite_doc[:, 'embedding']) == 5
+    assert len(annlite_doc[:, 'embedding']) == 6
 
 
-def test_add_conflict_id():
+def test_add_conflict_id(docs, update_docs):
     annlite_doc = DocumentArray(
         storage='annlite',
         config={
-            'n_dim': 3,
+            'n_dim': 4,
         },
     )
 
-    annlite_doc.extend(
-        [
-            Document(id='r0', embedding=[0, 0, 0]),
-            Document(id='r1', embedding=[1, 1, 1]),
-            Document(id='r2', embedding=[2, 2, 2]),
-            Document(id='r3', embedding=[3, 3, 3]),
-            Document(id='r4', embedding=[4, 4, 4]),
-        ]
-    )
+    annlite_doc.extend(docs)
 
     from sqlite3 import IntegrityError
 
     with pytest.raises(IntegrityError):
-        annlite_doc.extend(
-            [
-                Document(id='r0', embedding=[0, 0, 0]),
-                Document(id='r1', embedding=[1, 1, 1]),
-            ]
-        )
+        annlite_doc.extend(update_docs)

--- a/tests/docarray/test_del.py
+++ b/tests/docarray/test_del.py
@@ -1,0 +1,59 @@
+import pytest
+from docarray import Document, DocumentArray
+
+
+@pytest.mark.parametrize('deleted_elmnts', [[0, 1], ['r0', 'r1']])
+def test_delete_success(deleted_elmnts):
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    with annlite_doc:
+        annlite_doc.extend(
+            [
+                Document(id='r0', embedding=[0, 0, 0]),
+                Document(id='r1', embedding=[1, 1, 1]),
+                Document(id='r2', embedding=[2, 2, 2]),
+                Document(id='r3', embedding=[3, 3, 3]),
+                Document(id='r4', embedding=[4, 4, 4]),
+                Document(id='r5', embedding=[5, 5, 5]),
+                Document(id='r6', embedding=[6, 6, 6]),
+                Document(id='r7', embedding=[7, 7, 7]),
+            ]
+        )
+
+    expected_ids_after_del = ['r2', 'r3', 'r4', 'r5', 'r6', 'r7']
+
+    with annlite_doc:
+        del annlite_doc[deleted_elmnts]
+
+    assert len(annlite_doc._offset2ids.ids) == 6
+    assert len(annlite_doc[:, 'embedding']) == 6
+
+    for id in expected_ids_after_del:
+        assert id == annlite_doc[id].id
+
+
+@pytest.mark.parametrize('expected_failed_deleted_elmnts', [['r2', 'r3']])
+def test_delete_not_found(expected_failed_deleted_elmnts):
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+    with annlite_doc:
+        annlite_doc.extend(
+            [
+                Document(id='r0', embedding=[0, 0, 0]),
+                Document(id='r1', embedding=[1, 1, 1]),
+            ]
+        )
+
+    with pytest.raises(ValueError):
+        with annlite_doc:
+            for deleted_elmnts in expected_failed_deleted_elmnts:
+                del annlite_doc[deleted_elmnts]

--- a/tests/docarray/test_find.py
+++ b/tests/docarray/test_find.py
@@ -1,0 +1,26 @@
+import numpy as np
+from docarray import Document, DocumentArray
+
+
+def test_find():
+    nrof_docs = 1000
+    num_candidates = 100
+
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    with annlite_doc:
+        annlite_doc.extend(
+            [
+                Document(id=f'r{i}', embedding=np.ones((3,)) * i)
+                for i in range(nrof_docs)
+            ],
+        )
+
+    np_query = np.array([2, 1, 3])
+
+    annlite_doc.find(np_query, limit=10, num_candidates=num_candidates)

--- a/tests/docarray/test_get.py
+++ b/tests/docarray/test_get.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from docarray import Document, DocumentArray
+
+
+@pytest.mark.parametrize('nrof_docs', [10, 100, 10_000, 10_100, 20_000, 20_100])
+def test_success_get_bulk_data(nrof_docs):
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    with annlite_doc:
+        annlite_doc.extend(
+            [
+                Document(id=f'r{i}', embedding=np.ones((3,)) * i)
+                for i in range(nrof_docs)
+            ]
+        )
+
+    assert len(annlite_doc[:, 'id']) == nrof_docs
+
+
+def test_error_get_bulk_data_id_not_exist():
+    nrof_docs = 10
+
+    annlite_doc = DocumentArray(
+        storage='annlite',
+        config={
+            'n_dim': 3,
+        },
+    )
+
+    with annlite_doc:
+        annlite_doc.extend(
+            [
+                Document(id=f'r{i}', embedding=np.ones((3,)) * i)
+                for i in range(nrof_docs)
+            ]
+        )
+
+    with pytest.raises(KeyError) as e:
+        annlite_doc[['r1', 'r11', 'r21'], 'id']

--- a/tests/docarray/test_save_load.py
+++ b/tests/docarray/test_save_load.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from docarray import Document, DocumentArray
+
+
+def test_save_load(tmpdir):
+    save_da = DocumentArray(
+        storage='annlite', config={'n_dim': 768, 'data_path': tmpdir}
+    )
+    for i in range(100):
+        save_da.append(Document(id=str(i), embedding=np.random.rand(768)))
+
+    load_da = DocumentArray(
+        storage='annlite', config={'n_dim': 768, 'data_path': tmpdir}
+    )
+    assert len(load_da) == len(save_da)
+
+    for i in range(100, 120):
+        load_da.append(Document(id=str(i), embedding=np.random.rand(768)))
+    assert len(load_da) == 120


### PR DESCRIPTION
We have added some new features in `annlite` but these features somehow break the CI of `docarray`. So in order to prevent this happen again we migrate some unit tests from docarray to annlite.