### PR TITLE
fix: allow columns as dict format

### DIFF
--- a/annlite/container.py
+++ b/annlite/container.py
@@ -65,23 +65,15 @@ class CellContainer:
             for _ in range(n_cells)
         ]
 
-        columns = []
-        if kwargs.get('columns'):
+        columns = kwargs.get('columns', None)
+        if columns:
             warnings.warn(
-                'The parameter columns in tuple format is deprecated, please use the filterable_attrs in dict format',
-                'For example: columns=[("price", "float"), ("brand", "str")]',
-                'should be changed to filterable_attrs={"price": "float", "brand": "str"}',
+                'columns is deprecated, use filterable_attrs instead',
                 DeprecationWarning,
             )
-            columns = kwargs['columns']
 
         if filterable_attrs:
-            if len(columns) > 0:
-                warnings.warn(
-                    'The columns parameter is not used when filterable_attrs is provided'
-                )
-
-                columns = []
+            columns = []
             for attr_name, attr_type in filterable_attrs.items():
                 columns.append((attr_name, attr_type))
 

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -17,6 +17,8 @@ from .storage.base import ExpandMode
 from .storage.kv import DocStorage
 from .storage.table import CellTable, MetaTable
 
+VALID_FILTERABLE_DATA_TYPES = [int, str, float]
+
 
 class CellContainer:
     def __init__(
@@ -65,16 +67,16 @@ class CellContainer:
             for _ in range(n_cells)
         ]
 
-        columns = kwargs.get('columns', None)
-        if columns:
-            warnings.warn(
-                'columns is deprecated, use filterable_attrs instead',
-                DeprecationWarning,
-            )
-
+        columns = []
         if filterable_attrs:
-            columns = []
             for attr_name, attr_type in filterable_attrs.items():
+                if isinstance(attr_type, str):
+                    attr_type = eval(attr_type)
+
+                if attr_type not in VALID_FILTERABLE_DATA_TYPES:
+                    raise ValueError(
+                        f'Invalid filterable attribute type `{attr_type}` for attribute `{attr_name}`. '
+                    )
                 columns.append((attr_name, attr_type))
 
         self._cell_tables = [

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -21,7 +21,7 @@ from .storage.table import CellTable, MetaTable
 class CellContainer:
     def __init__(
         self,
-        dim: int,
+        n_dim: int,
         metric: Metric = Metric.COSINE,
         n_cells: int = 1,
         projector_codec: Optional['ProjectorCodec'] = None,
@@ -29,12 +29,12 @@ class CellContainer:
         initial_size: Optional[int] = None,
         expand_step_size: int = 50000,
         expand_mode: 'ExpandMode' = ExpandMode.STEP,
-        columns: Optional[List[tuple]] = None,
+        filterable_attrs: Optional[Dict[str]] = None,
         serialize_config: Optional[Dict] = None,
         data_path: 'Path' = Path('./data'),
         **kwargs,
     ):
-        self.dim = dim
+        self.n_dim = n_dim
         self.metric = metric
         self.n_cells = n_cells
         self.n_components = projector_codec.n_components if projector_codec else None
@@ -45,7 +45,7 @@ class CellContainer:
 
         self._vec_indexes = [
             HnswIndex(
-                dim=self.n_components or dim,
+                dim=self.n_components or n_dim,
                 metric=metric,
                 initial_size=initial_size,
                 expand_step_size=expand_step_size,
@@ -64,6 +64,26 @@ class CellContainer:
             )
             for _ in range(n_cells)
         ]
+
+        columns = []
+        if kwargs.get('columns'):
+            warnings.warn(
+                'The parameter columns in tuple format is deprecated, please use the filterable_attrs in dict format',
+                'For example: columns=[("price", "float"), ("brand", "str")]',
+                'should be changed to filterable_attrs={"price": "float", "brand": "str"}',
+                DeprecationWarning,
+            )
+            columns = kwargs['columns']
+
+        if filterable_attrs:
+            if len(columns) > 0:
+                warnings.warn(
+                    'The columns parameter is not used when filterable_attrs is provided'
+                )
+
+                columns = []
+            for attr_name, attr_type in filterable_attrs.items():
+                columns.append((attr_name, attr_type))
 
         self._cell_tables = [
             CellTable(f'table_{c}', columns=columns) for c in range(n_cells)
@@ -186,7 +206,7 @@ class CellContainer:
 
         topk_dists, topk_docs = [], []
         for x, cell_idx in zip(query, cells):
-            # x.shape = (self.dim,)
+            # x.shape = (self.n_dim,)
             dists, doc_ids, cells = self.ivf_search(
                 x,
                 cells=cell_idx,
@@ -285,7 +305,7 @@ class CellContainer:
 
     def _add_vecs(self, data: 'np.ndarray', cells: 'np.ndarray', offsets: 'np.ndarray'):
         assert data.shape[0] == cells.shape[0]
-        assert data.shape[1] == self.dim
+        assert data.shape[1] == self.n_dim
 
         unique_cells, _ = np.unique(cells, return_counts=True)
 

--- a/annlite/container.py
+++ b/annlite/container.py
@@ -29,7 +29,7 @@ class CellContainer:
         initial_size: Optional[int] = None,
         expand_step_size: int = 50000,
         expand_mode: 'ExpandMode' = ExpandMode.STEP,
-        filterable_attrs: Optional[Dict[str]] = None,
+        filterable_attrs: Optional[Dict] = None,
         serialize_config: Optional[Dict] = None,
         data_path: 'Path' = Path('./data'),
         **kwargs,

--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -31,7 +31,7 @@ class AnnLiteIndexer(Executor):
         filterable_attrs: Optional[Dict] = None,
         serialize_config: Optional[Dict] = None,
         dim: int = None,
-        columns: Optional[List[str]] = None,
+        columns: Optional[List[Tuple[str, str]]] = None,
         *args,
         **kwargs,
     ):

--- a/annlite/executor.py
+++ b/annlite/executor.py
@@ -19,7 +19,7 @@ class AnnLiteIndexer(Executor):
 
     def __init__(
         self,
-        dim: int = 0,
+        n_dim: int = 0,
         metric: str = 'cosine',
         limit: int = 10,
         ef_construction: int = 200,
@@ -34,7 +34,7 @@ class AnnLiteIndexer(Executor):
         **kwargs,
     ):
         """
-        :param dim: Dimensionality of vectors to index
+        :param n_dim: Dimensionality of vectors to index
         :param metric: Distance metric type. Can be 'euclidean', 'inner_product', or 'cosine'
         :param include_metadata: If True, return the document metadata in response
         :param limit: Number of results to get for each query document in search
@@ -53,7 +53,9 @@ class AnnLiteIndexer(Executor):
         super().__init__(*args, **kwargs)
         self.logger = JinaLogger(self.__class__.__name__)
 
-        if not dim:
+        n_dim = n_dim or kwargs.pop('dim', 0)
+
+        if not n_dim:
             raise ValueError('Please specify the dimension of the vectors to index!')
 
         self.metric = metric
@@ -93,7 +95,7 @@ class AnnLiteIndexer(Executor):
             columns = cols
 
         self._index = AnnLite(
-            dim=dim,
+            n_dim=n_dim,
             metric=metric,
             columns=columns,
             ef_construction=ef_construction,

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -62,7 +62,7 @@ class AnnLite(CellContainer):
         n_components: Optional[int] = None,
         initial_size: Optional[int] = None,
         expand_step_size: int = 10240,
-        filterable_attrs: Optional[Dict[str]] = None,
+        filterable_attrs: Optional[Dict] = None,
         data_path: Union[Path, str] = Path('./data'),
         create_if_missing: bool = True,
         read_only: bool = False,

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -112,7 +112,7 @@ class AnnLite(CellContainer):
             logger.info(
                 f'Initialize Projector codec (n_components={self.n_components})'
             )
-            self.projector_codec = ProjectorCodec(dim, n_components=self.n_components)
+            self.projector_codec = ProjectorCodec(n_dim, n_components=self.n_components)
 
         self.vq_codec = None
         if self._vq_codec_path.exists():
@@ -133,7 +133,7 @@ class AnnLite(CellContainer):
         elif n_subvectors:
             logger.info(f'Initialize PQ codec (n_subvectors={self.n_subvectors})')
             self.pq_codec = PQCodec(
-                dim=dim
+                dim=n_dim
                 if not self.projector_codec
                 else self.projector_codec.n_components,
                 n_subvectors=self.n_subvectors,
@@ -142,7 +142,7 @@ class AnnLite(CellContainer):
             )
 
         super(AnnLite, self).__init__(
-            dim=dim,
+            n_dim,
             metric=metric,
             projector_codec=self.projector_codec,
             pq_codec=self.pq_codec,

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -76,7 +77,7 @@ class AnnLite(CellContainer):
         setup_logging(verbose)
 
         if 'dim' in kwargs:
-            logger.warning(
+            warnings.warn(
                 'The argument `dim` will be deprecated, please use `n_dim` instead.'
             )
             n_dim = kwargs['dim']
@@ -147,6 +148,7 @@ class AnnLite(CellContainer):
         if columns is not None:
             if filterable_attrs:
                 logger.warning('`filterable_attrs` will be overwritten by `columns`.')
+
             filterable_attrs = {}
             for n, t in columns.items() if isinstance(columns, dict) else columns:
                 filterable_attrs[n] = t

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -41,7 +41,9 @@ class AnnLite(CellContainer):
             ``n_cells * initial_size`` is the number of vectors that can be stored initially.
             if any cell has reached its capacity, that cell will be automatically expanded.
             If you need to add vectors frequently, a larger value for init_size is recommended.
-    :param filterable_attrs: a list of attributes that can be used in filter.
+    :param columns: the columns to be indexed for fast filtering, default is None.
+    :param filterable_attrs: a dict of attributes to be indexed for fast filtering, default is None.
+            The key is the attribute name, and the value is the attribute type. And it only works when ``columns`` is None.
     :param data_path: path to the directory where the data is stored.
     :param create_if_missing: if False, do not create the directory path if it is missing.
     :param read_only: if True, the index is not writable.
@@ -62,6 +64,7 @@ class AnnLite(CellContainer):
         n_components: Optional[int] = None,
         initial_size: Optional[int] = None,
         expand_step_size: int = 10240,
+        columns: Optional[Union[Dict, List]] = None,
         filterable_attrs: Optional[Dict] = None,
         data_path: Union[Path, str] = Path('./data'),
         create_if_missing: bool = True,
@@ -74,7 +77,7 @@ class AnnLite(CellContainer):
 
         if 'dim' in kwargs:
             logger.warning(
-                'The argument `dim` is deprecated, please use `n_dim` instead.'
+                'The argument `dim` will be deprecated, please use `n_dim` instead.'
             )
             n_dim = kwargs['dim']
 
@@ -140,6 +143,13 @@ class AnnLite(CellContainer):
                 n_clusters=self.n_clusters,
                 metric=self.metric,
             )
+
+        if columns is not None:
+            if filterable_attrs:
+                logger.warning('`filterable_attrs` will be overwritten by `columns`.')
+            filterable_attrs = {}
+            for n, t in columns.items() if isinstance(columns, dict) else columns:
+                filterable_attrs[n] = t
 
         super(AnnLite, self).__init__(
             n_dim,

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -72,6 +72,12 @@ class AnnLite(CellContainer):
     ):
         setup_logging(verbose)
 
+        if 'dim' in kwargs:
+            logger.warning(
+                'The argument `dim` is deprecated, please use `n_dim` instead.'
+            )
+            n_dim = kwargs['dim']
+
         if n_subvectors:
             assert (
                 n_dim % n_subvectors == 0

--- a/annlite/index.py
+++ b/annlite/index.py
@@ -27,9 +27,9 @@ class AnnLite(CellContainer):
 
         .. highlight:: python
         .. code-block:: python
-            pqlite = AnnLite(256, metric='cosine')
+            ann = AnnLite(256, metric='cosine')
 
-    :param dim: dimensionality of input vectors. there are 2 constraints on dim:
+    :param n_dim: dimensionality of input vectors. there are 2 constraints on dim:
             (1) it needs to be divisible by n_subvectors; (2) it needs to be a multiple of 4.*
     :param metric: distance metric type, can be 'euclidean', 'inner_product', or 'cosine'.
     :param n_subvectors: number of sub-quantizers, essentially this is the byte size of
@@ -41,6 +41,7 @@ class AnnLite(CellContainer):
             ``n_cells * initial_size`` is the number of vectors that can be stored initially.
             if any cell has reached its capacity, that cell will be automatically expanded.
             If you need to add vectors frequently, a larger value for init_size is recommended.
+    :param filterable_attrs: a list of attributes that can be used in filter.
     :param data_path: path to the directory where the data is stored.
     :param create_if_missing: if False, do not create the directory path if it is missing.
     :param read_only: if True, the index is not writable.
@@ -52,7 +53,7 @@ class AnnLite(CellContainer):
 
     def __init__(
         self,
-        dim: int,
+        n_dim: int,
         metric: Union[str, Metric] = 'cosine',
         n_cells: int = 1,
         n_subvectors: Optional[int] = None,
@@ -61,7 +62,7 @@ class AnnLite(CellContainer):
         n_components: Optional[int] = None,
         initial_size: Optional[int] = None,
         expand_step_size: int = 10240,
-        columns: Optional[List[tuple]] = None,
+        filterable_attrs: Optional[Dict[str]] = None,
         data_path: Union[Path, str] = Path('./data'),
         create_if_missing: bool = True,
         read_only: bool = False,
@@ -73,9 +74,9 @@ class AnnLite(CellContainer):
 
         if n_subvectors:
             assert (
-                dim % n_subvectors == 0
-            ), '"dim" needs to be divisible by "n_subvectors"'
-        self.dim = dim
+                n_dim % n_subvectors == 0
+            ), '"n_dim" needs to be divisible by "n_subvectors"'
+        self.n_dim = n_dim
         self.n_components = n_components
         self.n_subvectors = n_subvectors
         self.n_clusters = n_clusters
@@ -142,7 +143,7 @@ class AnnLite(CellContainer):
             n_cells=n_cells,
             initial_size=initial_size,
             expand_step_size=expand_step_size,
-            columns=columns,
+            filterable_attrs=filterable_attrs,
             data_path=data_path,
             **kwargs,
         )
@@ -166,8 +167,8 @@ class AnnLite(CellContainer):
     def _sanity_check(self, x: 'np.ndarray'):
         assert x.ndim == 2, 'inputs must be a 2D array'
         assert (
-            x.shape[1] == self.dim
-        ), f'inputs must have the same dimension as the index , got {x.shape[1]}, expected {self.dim}'
+            x.shape[1] == self.n_dim
+        ), f'inputs must have the same dimension as the index , got {x.shape[1]}, expected {self.n_dim}'
 
         return x.shape
 
@@ -496,7 +497,7 @@ class AnnLite(CellContainer):
     @property
     def params_hash(self):
         model_metas = (
-            f'dim: {self.dim} '
+            f'n_dim: {self.n_dim} '
             f'metric: {self.metric} '
             f'n_cells: {self.n_cells} '
             f'n_components: {self.n_components} '
@@ -632,7 +633,7 @@ class AnnLite(CellContainer):
             'total_docs': self.total_docs,
             'index_size': self.index_size,
             'n_cells': self.n_cells,
-            'dim': self.dim,
+            'n_dim': self.n_dim,
             'n_components': self.n_components,
             'metric': self.metric.name,
             'is_trained': self.is_trained,

--- a/examples/benchmark_with_filtering.py
+++ b/examples/benchmark_with_filtering.py
@@ -56,7 +56,7 @@ for n_i in n_index:
         clean_workspace()
         columns = [('category', str)]
         idxer = AnnLite(
-            dim=D,
+            D,
             initial_size=n_i,
             n_cells=n_cells,
             metas={'workspace': './workspace'},

--- a/examples/filter_example.py
+++ b/examples/filter_example.py
@@ -56,7 +56,7 @@ for n_i in n_index:
 
     columns = [('category', str)]
     idxer = AnnLite(
-        dim=D,
+        D,
         initial_size=n_i,
         n_cells=n_cells,
         data_path='./workspace',

--- a/examples/hnsw_benchmark.py
+++ b/examples/hnsw_benchmark.py
@@ -81,7 +81,7 @@ for n_cells in [1, 8, 16, 32, 64, 128]:
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         pq = AnnLite(
-            dim=D,
+            D,
             metric='euclidean',
             n_cells=n_cells,
             max_connection=16,

--- a/examples/hnsw_example.py
+++ b/examples/hnsw_example.py
@@ -16,7 +16,7 @@ dirpath = tempfile.mkdtemp()
 with tempfile.TemporaryDirectory() as tmpdirname:
 
     index = AnnLite(
-        dim=D, columns=[('x', float)], data_path=tmpdirname, include_metadata=True
+        D, columns=[('x', float)], data_path=tmpdirname, include_metadata=True
     )
 
     X = np.random.random((N, D)).astype(

--- a/examples/pq_benchmark.py
+++ b/examples/pq_benchmark.py
@@ -44,9 +44,7 @@ results = []
 for n_cells in [1, 4, 8]:
     for n_subvectors in [64, 128]:
 
-        pq = AnnLite(
-            dim=D, metric='euclidean', n_cells=n_cells, n_subvectors=n_subvectors
-        )
+        pq = AnnLite(D, metric='euclidean', n_cells=n_cells, n_subvectors=n_subvectors)
 
         t0 = time.time()
         pq.train(Xtr[:20480])

--- a/examples/pqlinearscann_benchmark_with_filtering.py
+++ b/examples/pqlinearscann_benchmark_with_filtering.py
@@ -30,7 +30,7 @@ for n_i in n_index:
         clean_workspace()
         columns = [('category', str)]
         indexer = AnnLite(
-            dim=D,
+            D,
             initial_size=n_i,
             n_subvectors=n_subvectors,
             n_cells=n_cells,

--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -10,7 +10,7 @@ Nq = 5
 Nt = 2000
 D = 128  # dimensionality / number of features
 
-index = AnnLite(dim=D, data_path='/tmp/annlite_test')
+index = AnnLite(D, data_path='/tmp/annlite_test')
 
 X = np.random.random((N, D)).astype(np.float32)  # 10,000 128-dim vectors to be indexed
 

--- a/executor/README.md
+++ b/executor/README.md
@@ -72,17 +72,17 @@ One can run `benchmark.py` to get a quick performance overview.
 
 ## Getting Started
 
-For an in-depth overview of the features of PQLite
+For an in-depth overview of the features of AnnLite
 you can follow along with one of the examples below:
 
 
-| Name  | Link  |
-|---|---|
-| E-commerce product image search with PQLite  | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/pqlite/blob/main/notebooks/fashion_product_search.ipynb)|
+| Name                                         | Link  |
+|----------------------------------------------|---|
+| E-commerce product image search with AnnLite | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/pqlite/blob/main/notebooks/fashion_product_search.ipynb)|
 
 ## Quick Start
 
-`PQLiteIndexer` stores  `Document` objects at the  `workspace` directory, specified under the [`metas`](https://docs.jina.ai/fundamentals/executor/executor-built-in-features/#meta-attributes) attribute.
+`AnnLiteIndexer` stores  `Document` objects at the  `workspace` directory, specified under the [`metas`](https://docs.jina.ai/fundamentals/executor/executor-built-in-features/#meta-attributes) attribute.
 
 #### Example: Selecting items whose 'price' is less than 50
 

--- a/executor/benchmark.py
+++ b/executor/benchmark.py
@@ -16,7 +16,7 @@ times = {}
 
 for n_i in n_index:
     idxer = AnnLiteIndexer(
-        dim=D,
+        n_dim=D,
         initial_size=n_i,
         n_cells=n_cells,
     )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -108,12 +108,15 @@ def test_search(tmpdir):
             )
 
 
-def test_search_with_filtering(tmpdir):
+@pytest.mark.parametrize(
+    'columns',
+    [[('price', 'float'), ('category', 'str')], {'price': 'float', 'category': 'str'}],
+)
+def test_search_with_filtering(tmpdir, columns):
     metas = {'workspace': str(tmpdir)}
 
     docs = docs_with_tags(N)
     docs_query = gen_docs(1)
-    columns = [('price', 'float'), ('category', 'str')]
 
     f = Flow().add(
         uses=AnnLiteIndexer,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -135,7 +135,7 @@ def test_filter_without_query_vector():
     with tempfile.TemporaryDirectory() as tmpdirname:
         index = AnnLite(
             D,
-            filterable_attrs={'x', 'float'},
+            filterable_attrs={'x', float},
             data_path=tmpdirname,
             include_metadata=True,
         )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -135,7 +135,7 @@ def test_filter_without_query_vector():
     with tempfile.TemporaryDirectory() as tmpdirname:
         index = AnnLite(
             D,
-            filterable_attrs={'x', float},
+            filterable_attrs={'x': float},
             data_path=tmpdirname,
             include_metadata=True,
         )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,11 +1,12 @@
-import pytest
-
-from annlite.filter import Filter
-from docarray import DocumentArray, Document
-from annlite import AnnLite
-import tempfile
 import random
+import tempfile
+
 import numpy as np
+import pytest
+from docarray import Document, DocumentArray
+
+from annlite import AnnLite
+from annlite.filter import Filter
 
 
 def test_empty_filter():
@@ -112,7 +113,31 @@ def test_filter_without_query_vector():
     limit = 3
     with tempfile.TemporaryDirectory() as tmpdirname:
         index = AnnLite(
-            columns=[('x', float)], dim=D, data_path=tmpdirname, include_metadata=True
+            D, columns=[('x', float)], data_path=tmpdirname, include_metadata=True
+        )
+        X = np.random.random((N, D)).astype(np.float32)
+
+        docs = DocumentArray(
+            [
+                Document(id=f'{i}', embedding=X[i], tags={'x': random.random()})
+                for i in range(N)
+            ]
+        )
+        index.index(docs)
+
+        matches = index.filter(
+            filter={'x': {'$lt': 0.5}}, limit=limit, include_metadata=True
+        )
+        assert len(matches) == limit
+        for m in matches:
+            assert m.tags['x'] < 0.5
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        index = AnnLite(
+            D,
+            filterable_attrs={'x', 'float'},
+            data_path=tmpdirname,
+            include_metadata=True,
         )
         X = np.random.random((N, D)).astype(np.float32)
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -107,14 +107,15 @@ def test_error_filter():
         f.parse_where_clause()
 
 
-def test_filter_without_query_vector():
+@pytest.mark.parametrize(
+    'columns', [[('x', float)], [('x', 'float')], {'x': 'float'}, {'x': float}]
+)
+def test_filter_with_columns(columns):
     N = 100
     D = 2
     limit = 3
     with tempfile.TemporaryDirectory() as tmpdirname:
-        index = AnnLite(
-            D, columns=[('x', float)], data_path=tmpdirname, include_metadata=True
-        )
+        index = AnnLite(D, columns=columns, data_path=tmpdirname, include_metadata=True)
         X = np.random.random((N, D)).astype(np.float32)
 
         docs = DocumentArray(
@@ -132,10 +133,16 @@ def test_filter_without_query_vector():
         for m in matches:
             assert m.tags['x'] < 0.5
 
+
+@pytest.mark.parametrize('filterable_attrs', [{'x': 'float'}, {'x': float}])
+def test_filter_with_dict(filterable_attrs):
+    N = 100
+    D = 2
+    limit = 3
     with tempfile.TemporaryDirectory() as tmpdirname:
         index = AnnLite(
             D,
-            filterable_attrs={'x': float},
+            filterable_attrs=filterable_attrs,
             data_path=tmpdirname,
             include_metadata=True,
         )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -34,14 +34,14 @@ def annlite_index(tmpdir):
         np.float32
     )  # 2,000 128-dim vectors for training
 
-    index = AnnLite(dim=D, data_path=tmpdir / 'annlite_test')
+    index = AnnLite(n_dim=D, data_path=tmpdir / 'annlite_test')
     return index
 
 
 @pytest.fixture
 def annlite_with_data(tmpdir):
     columns = [('x', float)]
-    index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+    index = AnnLite(n_dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
 
     X = np.random.random((N, D)).astype(
         np.float32
@@ -63,7 +63,7 @@ def heterogenenous_da(tmpdir):
     categories = ['comics', 'movies', 'audiobook']
 
     columns = [('price', float), ('category', str)]
-    index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+    index = AnnLite(n_dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
 
     X = np.random.random((N, D)).astype(
         np.float32
@@ -88,7 +88,7 @@ def heterogenenous_da(tmpdir):
 def annlite_with_heterogeneous_tags(tmpdir, heterogenenous_da):
 
     columns = [('price', float), ('category', str)]
-    index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+    index = AnnLite(n_dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
     index.index(heterogenenous_da)
     return index
 

--- a/tests/test_pq_index.py
+++ b/tests/test_pq_index.py
@@ -24,7 +24,7 @@ def random_docs():
 
 def test_hnsw_pq_load_empty(tmpdir, random_docs):
     pq_index = AnnLite(
-        dim=D,
+        D,
         data_path=tmpdir / 'annlite_pq_test',
         n_subvectors=8,
     )
@@ -40,7 +40,7 @@ def test_hnsw_pq_load_empty(tmpdir, random_docs):
 
 def test_hnsw_pq_load(tmpdir, random_docs):
     pq_index = AnnLite(
-        dim=D,
+        D,
         data_path=tmpdir / 'annlite_pq_test',
         n_subvectors=8,
     )
@@ -56,7 +56,7 @@ def test_hnsw_pq_search_multi_clusters(n_clusters, tmpdir, random_docs):
     topk = 50
 
     X = random_docs.embeddings
-    no_pq_index = AnnLite(dim=D, data_path=tmpdir / 'annlite_test')
+    no_pq_index = AnnLite(D, data_path=tmpdir / 'annlite_test')
 
     query = DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
     test_query = DocumentArray([Document(embedding=X[i]) for i in range(total_test)])
@@ -65,7 +65,7 @@ def test_hnsw_pq_search_multi_clusters(n_clusters, tmpdir, random_docs):
     no_pq_index.search(query, limit=topk)
 
     pq_index = AnnLite(
-        dim=D,
+        D,
         data_path=tmpdir / f'annlite_pq_test',
         n_subvectors=8,
         n_clusters=n_clusters,

--- a/tests/test_projector_index.py
+++ b/tests/test_projector_index.py
@@ -18,7 +18,7 @@ def build_data():
 
 @pytest.fixture
 def build_projector_annlite(tmpdir):
-    index = AnnLite(dim=n_features, data_path=tmpdir / 'projector_annlite_test')
+    index = AnnLite(n_dim=n_features, data_path=tmpdir / 'projector_annlite_test')
     return index
 
 

--- a/tests/test_update_delete.py
+++ b/tests/test_update_delete.py
@@ -14,7 +14,7 @@ D = 128
 @pytest.fixture
 def annlite_with_data(tmpdir):
     columns = [('x', float)]
-    index = AnnLite(dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
+    index = AnnLite(n_dim=D, columns=columns, data_path=tmpdir / 'annlite_test')
 
     X = np.random.random((N, D)).astype(np.float32)
 


### PR DESCRIPTION

1.  allow `columns` accept both list and dict format.
2. add new parameter `filterable_attrs`
3. the positional parameter `dim` is renamed as `n_dim` (use the same parameter name as used in docarray)

**After this PR**:

```
from annlite import AnnLite

# use columns as a tuple list
ann = AnnLite(128, columns=[('x', 'float')])

# or as a dict
ann = AnnLite(128, columns={'x': 'float'})
```

And a new parameter `filterable_attrs` is added which works as `columns`. It only works when `columns` is not provided so that no broken changes are made. 

```
ann = AnnLite(128, filterable_attrs={'x': 'float'})

```
