### PR TITLE
fix: bump pybind11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "cython",
     "numpy>=1.10.0",
-    "pybind11>=2.0",
+    "pybind11>=2.9.0",
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
to close this building error
 
```
./bindings/hnsw_bindings.cpp:837:17: error: ‘attribute_error’ is not a member of ‘py’
       throw py::attribute_error(
                 ^~~~~~~~~~~~~~~
```

This is an upstream issue of pybind11 https://github.com/pybind/pybind11/issues/687. This issue has been addressed in [v2.8.1 ](https://github.com/pybind/pybind11/releases/tag/v2.8.1)