### PR TITLE
Fix close

### DIFF
--- a/annlite/index.py
+++ b/annlite/index.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
-import warnings
 import platform
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -92,6 +92,7 @@ class AnnLite(CellContainer):
         self.n_clusters = n_clusters
         self.n_probe = max(n_probe, n_cells)
         self.n_cells = n_cells
+        self._is_closed = False
 
         if isinstance(metric, str):
             metric = Metric.from_string(metric)
@@ -541,8 +542,14 @@ class AnnLite(CellContainer):
         self.meta_table.clear()
 
     def close(self):
+        if self._is_closed:
+            warnings.warn(
+                '`Annlite` had been closed already, will skip this close operation.'
+            )
+            return
         for cell_id in range(self.n_cells):
             self.doc_store(cell_id).close()
+        self._is_closed = True
 
     def encode(self, x: 'np.ndarray'):
         n_data, _ = self._sanity_check(x)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,50 @@
+import numpy as np
+from docarray import Document, DocumentArray
+
+
+def random_docs(
+    num_docs,
+    chunks_per_doc=5,
+    embed_dim=10,
+    jitter=1,
+    start_id=0,
+    embedding=True,
+    sparse_embedding=False,
+    text='hello world',
+) -> DocumentArray:
+    da = DocumentArray()
+    next_chunk_doc_id = start_id + num_docs
+    for j in range(num_docs):
+        doc_id = str(start_id + j)
+
+        d = Document(id=doc_id)
+        d.text = text
+        d.tags['id'] = f'myself id is: {doc_id}'
+        if embedding:
+            if sparse_embedding:
+                from scipy.sparse import coo_matrix
+
+                d.embedding = coo_matrix(
+                    (np.array([1, 1, 1]), (np.array([0, 1, 2]), np.array([1, 2, 1])))
+                )
+            else:
+                d.embedding = np.random.random(
+                    [embed_dim + np.random.randint(0, jitter)]
+                )
+
+        for _ in range(chunks_per_doc):
+            chunk_doc_id = str(next_chunk_doc_id)
+
+            c = Document(id=chunk_doc_id)
+            c.text = 'i\'m chunk %s from doc %s' % (chunk_doc_id, doc_id)
+            if embedding:
+                c.embedding = np.random.random(
+                    [embed_dim + np.random.randint(0, jitter)]
+                )
+            c.tags['parent_id'] = f'my parent is: {id}'
+            c.tags['id'] = f'myself id is: {doc_id}'
+            d.chunks.append(c)
+            next_chunk_doc_id += 1
+
+        da.append(d)
+    return da

--- a/tests/docarray/test_content.py
+++ b/tests/docarray/test_content.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from docarray import DocumentArray
+from docarray.array.annlite import AnnliteConfig, DocumentArrayAnnlite
+
+
+@pytest.mark.parametrize(
+    'content_attr', ['texts', 'embeddings', 'tensors', 'blobs', 'contents']
+)
+def test_content_empty_getter_return_none(content_attr):
+    da = DocumentArrayAnnlite(config={'n_dim': 3})
+    assert getattr(da, content_attr) is None
+
+
+@pytest.mark.parametrize(
+    'content_attr',
+    [
+        ('texts', ''),
+        ('embeddings', np.array([])),
+        ('tensors', np.array([])),
+        ('blobs', []),
+        ('contents', []),
+    ],
+)
+def test_content_empty_setter(content_attr):
+    da = DocumentArrayAnnlite(config={'n_dim': 3})
+
+    setattr(da, content_attr[0], content_attr[1])
+    assert getattr(da, content_attr[0]) is None
+
+
+@pytest.mark.parametrize(
+    'content_attr',
+    [
+        ('texts', ['s'] * 10),
+        ('tensors', np.random.random([10, 2])),
+        ('blobs', [b's'] * 10),
+    ],
+)
+def test_content_getter_setter(content_attr):
+    da = DocumentArrayAnnlite.empty(10, config=AnnliteConfig(n_dim=128))
+    setattr(da, content_attr[0], content_attr[1])
+    np.testing.assert_equal(da.contents, content_attr[1])
+    da.contents = content_attr[1]
+    np.testing.assert_equal(da.contents, content_attr[1])
+    np.testing.assert_equal(getattr(da, content_attr[0]), content_attr[1])
+    da.contents = None
+    assert da.contents is None
+
+
+@pytest.mark.parametrize('da_len', [0, 1, 2])
+def test_content_empty(da_len):
+    da = DocumentArrayAnnlite.empty(da_len, config=AnnliteConfig(n_dim=128))
+
+    assert not da.contents
+    assert not da.tensors
+    if da_len == 0:
+        assert not da.texts
+        assert not da.blobs
+    else:
+        assert da.texts == [''] * da_len
+        assert da.blobs == [b''] * da_len
+
+    da.texts = ['hello'] * da_len
+    if da_len == 0:
+        assert not da.contents
+    else:
+        assert da.contents == ['hello'] * da_len
+        assert da.texts == ['hello'] * da_len
+        assert not da.tensors
+        assert da.blobs == [b''] * da_len
+
+
+@pytest.mark.parametrize('da_len', [0, 1, 2])
+def test_embeddings_setter(da_len):
+    da = DocumentArrayAnnlite.empty(da_len, config=AnnliteConfig(n_dim=5))
+
+    da.embeddings = np.random.rand(da_len, 5)
+    for doc in da:
+        assert doc.embedding.shape == (5,)

--- a/tests/docarray/test_del.py
+++ b/tests/docarray/test_del.py
@@ -1,9 +1,15 @@
+import numpy as np
 import pytest
 from docarray import Document, DocumentArray
 
 
-@pytest.mark.parametrize('deleted_elmnts', [[0, 1], ['r0', 'r1']])
-def test_delete_success(deleted_elmnts):
+@pytest.fixture()
+def docs():
+    return DocumentArray([Document(id=f'{i}') for i in range(1, 10)])
+
+
+@pytest.mark.parametrize('deleted_elements', [[0, 1], ['r0', 'r1']])
+def test_delete_success(deleted_elements):
     annlite_doc = DocumentArray(
         storage='annlite',
         config={
@@ -28,7 +34,7 @@ def test_delete_success(deleted_elmnts):
     expected_ids_after_del = ['r2', 'r3', 'r4', 'r5', 'r6', 'r7']
 
     with annlite_doc:
-        del annlite_doc[deleted_elmnts]
+        del annlite_doc[deleted_elements]
 
     assert len(annlite_doc._offset2ids.ids) == 6
     assert len(annlite_doc[:, 'embedding']) == 6
@@ -37,8 +43,8 @@ def test_delete_success(deleted_elmnts):
         assert id == annlite_doc[id].id
 
 
-@pytest.mark.parametrize('expected_failed_deleted_elmnts', [['r2', 'r3']])
-def test_delete_not_found(expected_failed_deleted_elmnts):
+@pytest.mark.parametrize('expected_failed_deleted_elements', [['r2', 'r3']])
+def test_delete_not_found(expected_failed_deleted_elements):
     annlite_doc = DocumentArray(
         storage='annlite',
         config={
@@ -55,5 +61,84 @@ def test_delete_not_found(expected_failed_deleted_elmnts):
 
     with pytest.raises(ValueError):
         with annlite_doc:
-            for deleted_elmnts in expected_failed_deleted_elmnts:
+            for deleted_elmnts in expected_failed_deleted_elements:
                 del annlite_doc[deleted_elmnts]
+
+
+@pytest.mark.parametrize(
+    'storage, config',
+    [
+        ('annlite', {'n_dim': 3, 'metric': 'Euclidean'}),
+    ],
+)
+def test_del_subindex(storage, config):
+
+    D = 3
+
+    da = DocumentArray(
+        storage='annlite',
+        config={'n_dim': D, 'metric': 'Euclidean'},
+        subindex_configs={'@c': {'n_dim': 2}},
+    )
+
+    with da:
+        da.extend(
+            [
+                Document(
+                    id=str(i),
+                    embedding=i * np.ones(D),
+                    chunks=[
+                        Document(id=str(i) + '_0', embedding=np.array([i, i])),
+                        Document(id=str(i) + '_1', embedding=np.array([i, i])),
+                    ],
+                )
+                for i in range(10)
+            ]
+        )
+
+    del da['0']
+    assert len(da) == 9
+    assert len(da._subindices['@c']) == 18
+
+    del da[-2:]
+    assert len(da) == 7
+    assert len(da._subindices['@c']) == 14
+
+
+def test_del_subindex_annlite_multimodal():
+    from docarray import dataclass
+    from docarray.typing import Text
+
+    @dataclass
+    class MMDoc:
+        my_text: Text
+        my_other_text: Text
+
+    n_dim = 3
+    da = DocumentArray(
+        storage='annlite',
+        config={'n_dim': n_dim, 'metric': 'Euclidean'},
+        subindex_configs={'@.[my_text, my_other_text]': {'n_dim': 2}},
+    )
+
+    num_docs = 10
+    docs_to_add = DocumentArray(
+        [
+            Document(MMDoc(my_text='hello', my_other_text='world'))
+            for _ in range(num_docs)
+        ]
+    )
+    for i, d in enumerate(docs_to_add):
+        d.id = str(i)
+        d.embedding = i * np.ones(n_dim)
+        d.my_text.id = str(i) + '_0'
+        d.my_text.embedding = [i, i]
+        d.my_other_text.id = str(i) + '_1'
+        d.my_other_text.embedding = [i, i]
+
+    with da:
+        da.extend(docs_to_add)
+
+    del da['0']
+    assert len(da) == 9
+    assert len(da._subindices['@.[my_text, my_other_text]']) == 18

--- a/tests/docarray/test_eval.py
+++ b/tests/docarray/test_eval.py
@@ -1,0 +1,141 @@
+import copy
+
+import numpy as np
+import pytest
+from docarray import Document, DocumentArray
+
+
+@pytest.mark.parametrize(
+    'metric_fn, kwargs',
+    [
+        ('r_precision', {}),
+        ('precision_at_k', {}),
+        ('hit_at_k', {}),
+        ('average_precision', {}),
+        ('reciprocal_rank', {}),
+        ('recall_at_k', {'max_rel': 9}),
+        ('f1_score_at_k', {'max_rel': 9}),
+        ('ndcg_at_k', {}),
+    ],
+)
+def test_eval_mixin_perfect_match(metric_fn, kwargs):
+    da1 = DocumentArray.empty(10)
+    da1.embeddings = np.random.random([10, 256])
+    da1_index = DocumentArray(da1, storage='annlite', config={'n_dim': 256})
+    da1.match(da1_index, exclude_self=True)
+    r = da1.evaluate(da1, metric=metric_fn, strict=False, **kwargs)
+    assert isinstance(r, float)
+    assert r == 1.0
+    for d in da1:
+        assert d.evaluations[metric_fn].value == 1.0
+
+
+@pytest.mark.parametrize(
+    'metric_fn, kwargs',
+    [
+        ('r_precision', {}),
+        ('precision_at_k', {}),
+        ('hit_at_k', {}),
+        ('average_precision', {}),
+        ('reciprocal_rank', {}),
+        ('recall_at_k', {'max_rel': 9}),
+        ('f1_score_at_k', {'max_rel': 9}),
+        ('ndcg_at_k', {}),
+    ],
+)
+def test_eval_mixin_zero_match(metric_fn, kwargs):
+    da1 = DocumentArray.empty(10)
+    da1.embeddings = np.random.random([10, 256])
+    da1_index = DocumentArray(da1, storage='annlite', config={'n_dim': 256})
+    da1.match(da1_index, exclude_self=True)
+
+    da2 = copy.deepcopy(da1)
+    da2.embeddings = np.random.random([10, 256])
+    da2_index = DocumentArray(da2, storage='annlite', config={'n_dim': 256})
+    da2.match(da2_index, exclude_self=True)
+
+    r = da1.evaluate(da2, metric=metric_fn, **kwargs)
+    assert isinstance(r, float)
+    assert r == 1.0
+    for d in da1:
+        d: Document
+        assert d.evaluations[metric_fn].value == 1.0
+
+
+def test_diff_len_should_raise():
+    da1 = DocumentArray.empty(10)
+    da2 = DocumentArray.empty(5, storage='annlite', config={'n_dim': 256})
+    with pytest.raises(ValueError):
+        da1.evaluate(da2, metric='precision_at_k')
+
+
+def test_diff_hash_fun_should_raise():
+    da1 = DocumentArray.empty(10)
+    da2 = DocumentArray.empty(10, storage='annlite', config={'n_dim': 256})
+    with pytest.raises(ValueError):
+        da1.evaluate(da2, metric='precision_at_k')
+
+
+def test_same_hash_same_len_fun_should_work():
+    da1 = DocumentArray.empty(10)
+    da1.embeddings = np.random.random([10, 3])
+    da1_index = DocumentArray(da1, storage='annlite', config={'n_dim': 3})
+    da1.match(da1_index)
+    da2 = DocumentArray.empty(10)
+    da2.embeddings = np.random.random([10, 3])
+    da2_index = DocumentArray(da1, storage='annlite', config={'n_dim': 3})
+    da2.match(da2_index)
+    with pytest.raises(ValueError):
+        da1.evaluate(da2, metric='precision_at_k')
+    for d1, d2 in zip(da1, da2):
+        d1.id = d2.id
+
+    da1.evaluate(da2, metric='precision_at_k')
+
+
+def test_adding_noise():
+    da = DocumentArray.empty(10)
+
+    da.embeddings = np.random.random([10, 3])
+    da_index = DocumentArray(da, storage='annlite', config={'n_dim': 3})
+    da.match(da_index, exclude_self=True)
+
+    da2 = copy.deepcopy(da)
+
+    for d in da2:
+        d.matches.extend(DocumentArray.empty(10))
+        d.matches = d.matches.shuffle()
+
+    assert da2.evaluate(da, metric='precision_at_k', k=10) < 1.0
+
+    for d in da2:
+        assert 0.0 < d.evaluations['precision_at_k'].value < 1.0
+
+
+@pytest.mark.parametrize(
+    'metric_fn, kwargs',
+    [
+        ('recall_at_k', {}),
+        ('f1_score_at_k', {}),
+    ],
+)
+def test_diff_match_len_in_gd(metric_fn, kwargs):
+    da1 = DocumentArray.empty(10)
+    da1.embeddings = np.random.random([10, 128])
+    da1_index = DocumentArray(da1, storage='annlite', config={'n_dim': 128})
+    da1.match(da1, exclude_self=True)
+
+    da2 = copy.deepcopy(da1)
+    da2.embeddings = np.random.random([10, 128])
+    da2_index = DocumentArray(da2, storage='annlite', config={'n_dim': 128})
+    da2.match(da2_index, exclude_self=True)
+    # pop some matches from first document
+    da2[0].matches.pop(8)
+
+    r = da1.evaluate(da2, metric=metric_fn, **kwargs)
+    assert isinstance(r, float)
+    np.testing.assert_allclose(r, 1.0, rtol=1e-2)  #
+    for d in da1:
+        d: Document
+        # f1_score does not yield 1 for the first document as one of the match is missing
+        assert d.evaluations[metric_fn].value > 0.9

--- a/tests/docarray/test_find.py
+++ b/tests/docarray/test_find.py
@@ -1,26 +1,230 @@
+import operator
+
 import numpy as np
+import pytest
 from docarray import Document, DocumentArray
+from docarray.math import ndarray
 
 
-def test_find():
-    nrof_docs = 1000
-    num_candidates = 100
+@pytest.mark.parametrize('limit', [1, 5, 10])
+@pytest.mark.parametrize(
+    'query',
+    [np.random.random(32), np.random.random((1, 32)), np.random.random((2, 32))],
+)
+def test_find(limit, query):
+    embeddings = np.random.random((20, 32))
+    da = DocumentArray(storage='annlite', config={'n_dim': 32})
 
-    annlite_doc = DocumentArray(
-        storage='annlite',
-        config={
-            'n_dim': 3,
-        },
+    da.extend([Document(embedding=v) for v in embeddings])
+
+    result = da.find(query, limit=limit)
+    n_rows_query, n_dim = ndarray.get_array_rows(query)
+
+    if n_rows_query == 1 and n_dim == 1:
+        # we expect a result to be DocumentArray
+        assert len(result) == limit
+    elif n_rows_query == 1 and n_dim == 2:
+        # we expect a result to be a list with 1 DocumentArray
+        assert len(result) == 1
+        assert len(result[0]) == limit
+    else:
+        # check for each row on the query a DocumentArray is returned
+        assert len(result) == n_rows_query
+
+    # check returned objects are sorted according to the storage backend metric
+    # weaviate uses cosine similarity by default
+    # annlite uses cosine distance by default
+    if n_dim == 1:
+        cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
+        assert sorted(cosine_distances, reverse=False) == cosine_distances
+    else:
+        for da in result:
+            cosine_distances = [t['cosine'].value for t in da[:, 'scores']]
+            assert sorted(cosine_distances, reverse=False) == cosine_distances
+
+
+numeric_operators_annlite = {
+    '$gte': operator.ge,
+    '$gt': operator.gt,
+    '$lte': operator.le,
+    '$lt': operator.lt,
+    '$eq': operator.eq,
+    '$neq': operator.ne,
+}
+
+
+@pytest.mark.parametrize(
+    'storage,filter_gen,numeric_operators,operator',
+    [
+        *[
+            tuple(
+                [
+                    'annlite',
+                    lambda operator, threshold: {'price': {operator: threshold}},
+                    numeric_operators_annlite,
+                    operator,
+                ]
+            )
+            for operator in numeric_operators_annlite.keys()
+        ],
+    ],
+)
+@pytest.mark.parametrize('columns', [[('price', 'int')], {'price': 'int'}])
+def test_search_pre_filtering(
+    storage, filter_gen, operator, numeric_operators, columns
+):
+    np.random.seed(0)
+    n_dim = 128
+
+    da = DocumentArray(storage=storage, config={'n_dim': n_dim, 'columns': columns})
+
+    da.extend(
+        [
+            Document(id=f'r{i}', embedding=np.random.rand(n_dim), tags={'price': i})
+            for i in range(50)
+        ]
     )
+    thresholds = [10, 20, 30]
 
-    with annlite_doc:
-        annlite_doc.extend(
-            [
-                Document(id=f'r{i}', embedding=np.ones((3,)) * i)
-                for i in range(nrof_docs)
-            ],
+    for threshold in thresholds:
+
+        filter = filter_gen(operator, threshold)
+
+        results = da.find(np.random.rand(n_dim), filter=filter)
+
+        assert len(results) > 0
+
+        assert all(
+            [numeric_operators[operator](r.tags['price'], threshold) for r in results]
         )
 
-    np_query = np.array([2, 1, 3])
 
-    annlite_doc.find(np_query, limit=10, num_candidates=num_candidates)
+@pytest.mark.parametrize(
+    'storage,filter_gen,numeric_operators,operator',
+    [
+        *[
+            tuple(
+                [
+                    'annlite',
+                    lambda operator, threshold: {'price': {operator: threshold}},
+                    numeric_operators_annlite,
+                    operator,
+                ]
+            )
+            for operator in numeric_operators_annlite.keys()
+        ],
+    ],
+)
+@pytest.mark.parametrize('columns', [[('price', 'float')], {'price': 'float'}])
+def test_filtering(storage, filter_gen, operator, numeric_operators, columns):
+    n_dim = 128
+
+    da = DocumentArray(storage=storage, config={'n_dim': n_dim, 'columns': columns})
+
+    da.extend([Document(id=f'r{i}', tags={'price': i}) for i in range(50)])
+    thresholds = [10, 20, 30]
+
+    for threshold in thresholds:
+
+        filter = filter_gen(operator, threshold)
+        results = da.find(filter=filter)
+
+        assert len(results) > 0
+
+        assert all(
+            [numeric_operators[operator](r.tags['price'], threshold) for r in results]
+        )
+
+
+def test_find_subindex():
+    n_dim = 3
+    subindex_configs = {'@c': None}
+    subindex_configs['@c'] = {'n_dim': 2}
+
+    da = DocumentArray(
+        storage='annlite',
+        config={'n_dim': 3, 'metric': 'Euclidean'},
+        subindex_configs=subindex_configs,
+    )
+
+    with da:
+        da.extend(
+            [
+                Document(
+                    id=str(i),
+                    embedding=i * np.ones(n_dim),
+                    chunks=[
+                        Document(id=str(i) + '_0', embedding=np.array([i, i])),
+                        Document(id=str(i) + '_1', embedding=np.array([i, i])),
+                    ],
+                )
+                for i in range(3)
+            ]
+        )
+
+    closest_docs = da.find(query=np.array([3, 3]), on='@c')
+
+    b = closest_docs[0].embedding == [2, 2]
+    if isinstance(b, bool):
+        assert b
+    else:
+        assert b.all()
+    for d in closest_docs:
+        assert d.id.endswith('_0') or d.id.endswith('_1')
+
+
+def test_find_subindex_multimodal():
+    from docarray import dataclass
+    from docarray.typing import Text
+
+    @dataclass
+    class MMDoc:
+        my_text: Text
+        my_other_text: Text
+        my_third_text: Text
+
+    n_dim = 3
+    subindex_configs = {
+        '@.[my_text, my_other_text]': {'n_dim': 2},
+        '@.[my_third_text]': {'n_dim': 2},
+    }
+
+    da = DocumentArray(
+        storage='annlite',
+        config={'n_dim': 3, 'metric': 'Euclidean'},
+        subindex_configs=subindex_configs,
+    )
+
+    num_docs = 3
+    docs_to_add = DocumentArray(
+        [
+            Document(
+                MMDoc(
+                    my_text='hello', my_other_text='world', my_third_text='hello again'
+                )
+            )
+            for _ in range(num_docs)
+        ]
+    )
+    for i, d in enumerate(docs_to_add):
+        d.id = str(i)
+        d.embedding = i * np.ones(n_dim)
+        d.my_text.id = str(i) + '_0'
+        d.my_text.embedding = np.array([i, i])
+        d.my_other_text.id = str(i) + '_1'
+        d.my_other_text.embedding = np.array([i, i])
+        d.my_third_text.id = str(i) + '_2'
+        d.my_third_text.embedding = np.array([3 * i, 3 * i])
+
+    with da:
+        da.extend(docs_to_add)
+
+    closest_docs = da.find(query=np.array([3, 3]), on='@.[my_text, my_other_text]')
+    assert (closest_docs[0].embedding == np.array([2, 2])).all()
+    for d in closest_docs:
+        assert d.id.endswith('_0') or d.id.endswith('_1')
+
+    closest_docs = da.find(query=np.array([3, 3]), on='@.[my_third_text]')
+    assert (closest_docs[0].embedding == np.array([3, 3])).all()
+    for d in closest_docs:
+        assert d.id.endswith('_2')

--- a/tests/docarray/test_getset.py
+++ b/tests/docarray/test_getset.py
@@ -1,0 +1,331 @@
+import numpy as np
+import pytest
+import scipy.sparse
+from docarray import Document, DocumentArray
+from docarray.array.annlite import AnnliteConfig, DocumentArrayAnnlite
+
+from tests import random_docs
+
+rand_array = np.random.random([10, 3])
+
+
+@pytest.fixture()
+def docs():
+    rand_docs = random_docs(100)
+    return rand_docs
+
+
+@pytest.fixture()
+def nested_docs():
+    docs = [
+        Document(id='r1', chunks=[Document(id='c1'), Document(id='c2')]),
+        Document(id='r2', matches=[Document(id='m1'), Document(id='m2')]),
+    ]
+    return docs
+
+
+def test_da_get_embeddings(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+
+    da.extend(docs)
+    np.testing.assert_almost_equal(da._get_attributes('embedding'), da.embeddings)
+    np.testing.assert_almost_equal(da[:, 'embedding'], da.embeddings)
+
+
+def test_embeddings_setter_da(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+
+    da.extend(docs)
+    emb = np.random.random((100, 10))
+    da[:, 'embedding'] = emb
+    np.testing.assert_almost_equal(da.embeddings, emb)
+
+    for x, doc in zip(emb, da):
+        np.testing.assert_almost_equal(x, doc.embedding)
+
+    da[:, 'embedding'] = None
+    if hasattr(da, 'flush'):
+        da.flush()
+    assert da.embeddings is None or not np.any(da.embeddings)
+
+
+def test_embeddings_wrong_len(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+
+    da.extend(docs)
+    embeddings = np.ones((2, 10))
+
+    with pytest.raises(ValueError):
+        da.embeddings = embeddings
+
+
+def test_tensors_getter_da(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+
+    da.extend(docs)
+    tensors = np.random.random((100, 10, 10))
+    da.tensors = tensors
+    assert len(da) == 100
+    np.testing.assert_almost_equal(da.tensors, tensors)
+
+    da.tensors = None
+    assert da.tensors is None
+
+
+def test_texts_getter_da(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+
+    da.extend(docs)
+    assert len(da.texts) == 100
+    assert da.texts == da[:, 'text']
+    texts = ['text' for _ in range(100)]
+    da.texts = texts
+    assert da.texts == texts
+
+    for x, doc in zip(texts, da):
+        assert x == doc.text
+
+    da.texts = None
+    if hasattr(da, 'flush'):
+        da.flush()
+
+    # unfortunately protobuf does not distinguish None and '' on string
+    # so non-set str field in Pb is ''
+    assert set(da.texts) == set([''])
+
+
+def test_setter_by_sequences_in_selected_docs_da(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(docs)
+    da[[0, 1, 2], 'text'] = 'test'
+    assert da[[0, 1, 2], 'text'] == ['test', 'test', 'test']
+
+    da[[3, 4], 'text'] = ['test', 'test']
+    assert da[[3, 4], 'text'] == ['test', 'test']
+
+    da[[0], 'text'] = ['jina']
+    assert da[[0], 'text'] == ['jina']
+
+    da[[6], 'text'] = ['test']
+    assert da[[6], 'text'] == ['test']
+
+    # test that ID not present in da works
+    da[[0], 'id'] = '999'
+    assert ['999'] == da[[0], 'id']
+
+    da[[0, 1], 'id'] = ['101', '102']
+    assert ['101', '102'] == da[[0, 1], 'id']
+
+
+def test_texts_wrong_len(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(docs)
+    texts = ['hello']
+
+    with pytest.raises(ValueError):
+        da.texts = texts
+
+
+def test_tensors_wrong_len(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(docs)
+    tensors = np.ones((2, 10, 10))
+
+    with pytest.raises(ValueError):
+        da.tensors = tensors
+
+
+def test_blobs_getter_setter(docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(docs)
+    with pytest.raises(ValueError):
+        da.blobs = [b'cc', b'bb', b'aa', b'dd']
+
+    da.blobs = [b'aa'] * len(da)
+    assert da.blobs == [b'aa'] * len(da)
+
+    da.blobs = None
+    if hasattr(da, 'flush'):
+        da.flush()
+
+    # unfortunately protobuf does not distinguish None and '' on string
+    # so non-set str field in Pb is ''
+    assert set(da.blobs) == set([b''])
+
+
+def test_ellipsis_getter(nested_docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(nested_docs)
+    flattened = da[...]
+    assert len(flattened) == 6
+    for d, doc_id in zip(flattened, ['c1', 'c2', 'r1', 'm1', 'm2', 'r2']):
+        assert d.id == doc_id
+
+
+def test_ellipsis_attribute_setter(nested_docs):
+    da = DocumentArrayAnnlite(config=AnnliteConfig(n_dim=10))
+    da.extend(nested_docs)
+    da[..., 'text'] = 'new'
+    assert all(d.text == 'new' for d in da[...])
+
+
+def test_zero_embeddings():
+    a = np.zeros([10, 6])
+    da = DocumentArrayAnnlite.empty(10, config=AnnliteConfig(n_dim=6))
+
+    # all zero, dense
+    da[:, 'embedding'] = a
+    np.testing.assert_almost_equal(da.embeddings, a)
+    for d in da:
+        assert d.embedding.shape == (6,)
+
+    # all zero, sparse
+    sp_a = scipy.sparse.coo_matrix(a)
+    da[:, 'embedding'] = sp_a
+    np.testing.assert_almost_equal(da.embeddings.todense(), sp_a.todense())
+    for d in da:
+        # scipy sparse row-vector can only be a (1, m) not squeezible
+        assert d.embedding.shape == (1, 6)
+
+    # near zero, sparse
+    a = np.random.random([10, 6])
+    a[a > 0.1] = 0
+    sp_a = scipy.sparse.coo_matrix(a)
+    da[:, 'embedding'] = sp_a
+    np.testing.assert_almost_equal(da.embeddings.todense(), sp_a.todense())
+    for d in da:
+        # scipy sparse row-vector can only be a (1, m) not squeezible
+        assert d.embedding.shape == (1, 6)
+
+
+def embeddings_eq(emb1, emb2):
+    b = emb1 == emb2
+    if isinstance(b, bool):
+        return b
+    else:
+        return b.all()
+
+
+def test_getset_subindex():
+
+    n_dim = 3
+    subindex_configs = {'@c': {'n_dim': 2}}
+
+    da = DocumentArray(
+        storage='annlite',
+        config={'n_dim': 3, 'metric': 'Euclidean'},
+        subindex_configs=subindex_configs,
+    )
+
+    with da:
+        da.extend(
+            [
+                Document(
+                    id=str(i),
+                    embedding=i * np.ones(n_dim),
+                    chunks=[
+                        Document(id=str(i) + '_0', embedding=np.array([i, i])),
+                        Document(id=str(i) + '_1', embedding=np.array([i, i])),
+                    ],
+                )
+                for i in range(3)
+            ]
+        )
+    with da:
+        da[0] = Document(
+            embedding=-1 * np.ones(n_dim),
+            chunks=[
+                Document(id='c_0', embedding=np.array([-1, -1])),
+                Document(id='c_1', embedding=np.array([-2, -2])),
+            ],
+        )
+
+    with da:
+        da[1:] = [
+            Document(
+                embedding=-1 * np.ones(n_dim),
+                chunks=[
+                    Document(id='c_0' + str(i), embedding=np.array([-1, -1])),
+                    Document(id='c_1' + str(i), embedding=np.array([-2, -2])),
+                ],
+            )
+            for i in range(2)
+        ]
+
+    # test insert single doc
+    assert embeddings_eq(da[0].embedding, -1 * np.ones(n_dim))
+    assert embeddings_eq(da[0].chunks[0].embedding, [-1, -1])
+    assert embeddings_eq(da[0].chunks[1].embedding, [-2, -2])
+
+    assert embeddings_eq(da._subindices['@c']['c_0'].embedding, [-1, -1])
+    assert embeddings_eq(da._subindices['@c']['c_1'].embedding, [-2, -2])
+
+    # test insert slice of docs
+    assert embeddings_eq(da[1].embedding, -1 * np.ones(n_dim))
+    assert embeddings_eq(da[1].chunks[0].embedding, [-1, -1])
+    assert embeddings_eq(da[1].chunks[1].embedding, [-2, -2])
+
+    assert embeddings_eq(da._subindices['@c']['c_00'].embedding, [-1, -1])
+    assert embeddings_eq(da._subindices['@c']['c_10'].embedding, [-2, -2])
+
+    assert embeddings_eq(da[2].embedding, -1 * np.ones(n_dim))
+    assert embeddings_eq(da[2].chunks[0].embedding, [-1, -1])
+    assert embeddings_eq(da[2].chunks[1].embedding, [-2, -2])
+
+    assert embeddings_eq(da._subindices['@c']['c_01'].embedding, [-1, -1])
+    assert embeddings_eq(da._subindices['@c']['c_11'].embedding, [-2, -2])
+
+
+def test_init_subindex():
+
+    num_top_level_docs = 5
+    num_chunks_per_doc = 3
+    subindex_configs = {'@c': {'n_dim': 2}}
+
+    da = DocumentArray(
+        [
+            Document(
+                chunks=[Document(text=f'{i}{j}') for j in range(num_chunks_per_doc)]
+            )
+            for i in range(num_top_level_docs)
+        ],
+        storage='annlite',
+        config={'n_dim': 3, 'metric': 'Euclidean'},
+        subindex_configs=subindex_configs,
+    )
+
+    assert len(da['@c']) == num_top_level_docs * num_chunks_per_doc
+    assert len(da._subindices['@c']) == num_top_level_docs * num_chunks_per_doc
+    expected_texts = []
+    for i in range(num_top_level_docs):
+        for j in range(num_chunks_per_doc):
+            expected_texts.append(f'{i}{j}')
+    assert da['@c'].texts == expected_texts
+    assert da._subindices['@c'].texts == expected_texts
+
+
+def test_set_on_subindex():
+    n_dim = 3
+    subindex_configs = {'@c': {'n_dim': 2}}
+
+    da = DocumentArray(
+        [Document(chunks=[Document() for j in range(3)]) for i in range(5)],
+        storage='annlite',
+        config={'n_dim': 3, 'metric': 'Euclidean'},
+        subindex_configs=subindex_configs,
+    )
+
+    embeddings_to_assign = np.random.random((5 * 3, 2))
+    with da:
+        da['@c'].embeddings = embeddings_to_assign
+    assert (da['@c'].embeddings == embeddings_to_assign).all()
+    assert (da._subindices['@c'].embeddings == embeddings_to_assign).all()
+
+    with da:
+        da['@c'].texts = ['hello' for _ in range(5 * 3)]
+    assert da['@c'].texts == ['hello' for _ in range(5 * 3)]
+    assert da._subindices['@c'].texts == ['hello' for _ in range(5 * 3)]
+
+    matches = da.find(query=np.random.random(2), on='@c')
+    assert matches
+    assert len(matches[0].embedding) == 2

--- a/tests/docarray/test_io.py
+++ b/tests/docarray/test_io.py
@@ -1,0 +1,171 @@
+import os
+import uuid
+
+import numpy as np
+import pytest
+from docarray import Document, DocumentArray
+from docarray.array.annlite import AnnliteConfig, DocumentArrayAnnlite
+from docarray.helper import random_identity
+
+from tests import random_docs
+
+
+@pytest.fixture
+def docs():
+    return random_docs(100)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('method', ['json', 'binary'])
+@pytest.mark.parametrize('encoding', ['utf-8', 'cp1252'])
+def test_document_save_load(docs, method, encoding, tmpfile):
+
+    da = DocumentArrayAnnlite(docs, config=AnnliteConfig(n_dim=10))
+    # da.insert(2, Document(id='new'))
+    da.save(tmpfile, file_format=method, encoding=encoding)
+
+    del da
+
+    da_r = DocumentArrayAnnlite.load(
+        tmpfile, file_format=method, encoding=encoding, config=AnnliteConfig(n_dim=10)
+    )
+
+    # assert da_r[2].id == 'new'
+    # assert len(da_r) == len(docs)
+    # for d, d_r in zip(docs, da_r):
+    #     assert d.id == d_r.id
+    #     np.testing.assert_equal(d.embedding, d_r.embedding)
+    #     assert d.content == d_r.content
+
+
+@pytest.mark.parametrize('flatten_tags', [True, False])
+def test_da_csv_write(docs, flatten_tags, tmpdir):
+    tmpfile = os.path.join(tmpdir, 'test.csv')
+    da = DocumentArrayAnnlite(docs, config=AnnliteConfig(n_dim=10))
+    da.save_csv(tmpfile, flatten_tags)
+    with open(tmpfile) as fp:
+        assert len([v for v in fp]) == len(da) + 1
+
+
+def test_from_ndarray():
+    _da = DocumentArrayAnnlite.from_ndarray(
+        np.random.random([10, 256]), config=AnnliteConfig(n_dim=256)
+    )
+
+    assert len(_da) == 10
+
+
+def test_from_files():
+    assert (
+        len(
+            DocumentArrayAnnlite.from_files(
+                patterns='*.*',
+                to_dataturi=True,
+                size=1,
+                config=AnnliteConfig(n_dim=256),
+            )
+        )
+        == 1
+    )
+
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_from_files_exclude():
+    da1 = DocumentArray.from_files(f'{cur_dir}/*.*')
+    has_init = False
+    for s in da1[:, 'uri']:
+        if s.endswith('__init__.py'):
+            has_init = True
+            break
+    assert has_init
+    da2 = DocumentArray.from_files('*.*', exclude_regex=r'__.*\.py')
+    has_init = False
+    for s in da2[:, 'uri']:
+        if s.endswith('__init__.py'):
+            has_init = True
+            break
+    assert not has_init
+
+
+def test_from_ndjson():
+    with open(os.path.join(cur_dir, 'docs.jsonlines')) as fp:
+        _da = DocumentArrayAnnlite.from_ndjson(fp, config=AnnliteConfig(n_dim=256))
+        assert len(_da) == 2
+
+
+def test_from_to_pd_dataframe():
+    df = DocumentArrayAnnlite.empty(2, config=AnnliteConfig(n_dim=3)).to_dataframe()
+    assert (
+        len(DocumentArrayAnnlite.from_dataframe(df, config=AnnliteConfig(n_dim=3))) == 2
+    )
+
+    # more complicated
+    da = DocumentArrayAnnlite.empty(2, config=AnnliteConfig(n_dim=3))
+
+    da[:, 'embedding'] = [[1, 2, 3], [4, 5, 6]]
+    da[:, 'tensor'] = [[1, 2], [2, 1]]
+    da[0, 'tags'] = {'hello': 'world'}
+    df = da.to_dataframe()
+
+    da2 = DocumentArrayAnnlite.from_dataframe(df, config=AnnliteConfig(n_dim=3))
+
+    assert da2[0].tags == {'hello': 'world'}
+    assert da2[1].tags == {}
+
+
+def test_from_to_bytes():
+    # simple
+    assert (
+        len(
+            DocumentArrayAnnlite.load_binary(
+                bytes(DocumentArrayAnnlite.empty(2, config=AnnliteConfig(n_dim=3)))
+            )
+        )
+        == 2
+    )
+
+    da = DocumentArrayAnnlite.empty(2, config=AnnliteConfig(n_dim=3))
+
+    da[:, 'embedding'] = [[1, 2, 3], [4, 5, 6]]
+    da[:, 'tensor'] = [[1, 2], [2, 1]]
+    da[0, 'tags'] = {'hello': 'world'}
+    da2 = DocumentArrayAnnlite.load_binary(bytes(da))
+    assert da2.tensors == [[1, 2], [2, 1]]
+    import numpy as np
+
+    np.testing.assert_array_equal(da2.embeddings, [[1, 2, 3], [4, 5, 6]])
+    # assert da2.embeddings == [[1, 2, 3], [4, 5, 6]]
+    assert da2[0].tags == {'hello': 'world'}
+    assert da2[1].tags == {}
+
+
+@pytest.mark.parametrize('show_progress', [True, False])
+def test_push_pull_io(show_progress):
+    da1 = DocumentArrayAnnlite.empty(10, config=AnnliteConfig(n_dim=256))
+
+    da1[:, 'embedding'] = np.random.random([len(da1), 256])
+    random_texts = [str(uuid.uuid1()) for _ in da1]
+    da1[:, 'text'] = random_texts
+
+    name = f'docarray_ci_{random_identity()}'
+
+    da1.push(name, show_progress=show_progress)
+
+    da2 = DocumentArrayAnnlite.pull(
+        name, show_progress=show_progress, config=AnnliteConfig(n_dim=256)
+    )
+
+    assert len(da1) == len(da2) == 10
+    assert da1.texts == da2.texts == random_texts
+
+    all_names = DocumentArray.cloud_list()
+
+    assert name in all_names
+
+    DocumentArray.cloud_delete(name)
+
+    all_names = DocumentArray.cloud_list()
+
+    assert name not in all_names


### PR DESCRIPTION
we add a flag for denoting whether `Annlite` has been closed already. This can avoid errors when closing `Annlite` twice.