### PR TITLE
fix: cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [['3.7', "cp37"], ['3.8', "cp38"], ['3.9', "cp39"], ['3.10', "cp310"]]
+        python-version: [['3.7', "cp37"]]
         test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     steps:
       - name: Set up Python ${{ matrix.python-version[0] }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,8 +89,6 @@ jobs:
       - name: Test unix
         id: test_unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
-        env:
-          OPENBLAS_CORETYPE: ARMV8
         run: |
           cd ..
           mv annlite/tests/ ./

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,16 +129,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 100
-#      - uses: actions/download-artifact@v3
-#        with:
-#          name: artifact
-#          path: dist
+     - uses: actions/download-artifact@v3
+       with:
+         name: artifact
+         path: dist
       - name: Pre-release (.devN)
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           pip install twine wheel build
           ./scripts/release.sh
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME_TEST }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_TEST }}
+          # JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
-  build-wheels:
+  build-package:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,6 +31,14 @@ jobs:
         cpython-version: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
     steps:
       - uses: actions/checkout@v3
+      - name: Update version
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          ./scripts/update-version.sh
+      - name: Build sdist
+      - run: |
+          pip install build
+          python -m build --sdist
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.10.2
         with:
@@ -46,7 +54,9 @@ jobs:
           CIBW_BUILD_FRONTEND: build
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: |
+            ./wheelhouse/*.whl
+            ./dist/*.tar.gz
 
   core-test:
     needs: [prep-testbed, build-wheels]
@@ -136,9 +146,8 @@ jobs:
       - name: Pre-release (.devN)
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          pip install twine wheel build
           ./scripts/release.sh
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME_TEST }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_TEST }}
-          # JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
+          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cpython-version }}
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          CIBW_ARCH_MACOS: x86_64 arm64
           CIBW_BUILD_FRONTEND: build
       - uses: actions/upload-artifact@v3
         with:
@@ -80,7 +81,7 @@ jobs:
       - name: Install annlite macos
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          pip install dist/*${{ matrix.python-version[1] }}**macos*.whl
+          pip install dist/*${{ matrix.python-version[1] }}**macos**x86_64*.whl
       - name: Install annlite win
         if: ${{ matrix.os == 'windows-latest'}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          pip install jina
+          pip install --pre docarray
+          pip install pytest pytest-html pytest-cov pytest-mock pytest-repeat pytest-custom-exit-code pytest-timeout pytest-reraise
       - name: Build wheel
         uses: pypa/cibuildwheel@v2.10.2
         with:
@@ -120,18 +127,10 @@ jobs:
           CIBW_BUILD: ${{ matrix.cpython-version }}
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
-          CIBW_OUTPUT_DIR: "dist"
           CIBW_BUILD_FRONTEND: build
-      - uses: actions/checkout@v3
       - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*.whl
-      - name: Prepare enviroment
-        run: |
-          python -m pip install --upgrade pip
-          pip install jina
-          pip install --pre docarray
-          pip install pytest pytest-html pytest-cov pytest-mock pytest-repeat pytest-custom-exit-code pytest-timeout pytest-reraise
       - name: Install annlite unix
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,20 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
+  upload-test:
+    needs: [core-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_TEST }}
+          repository_url: https://test.pypi.org/legacy/
+
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     needs: [core-test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,6 @@ jobs:
       - name: Test unix
         id: test_unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
-        env:
-          OPENBLAS_CORETYPE: ARMV8
         run: |
           cd ..
           mv annlite/tests/ ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,15 +130,15 @@ jobs:
           CIBW_BUILD_FRONTEND: build
       - uses: actions/upload-artifact@v3
         with:
-          path: ./dist/*.whl
+          path: ./wheelhouse/*.whl
       - name: Install annlite unix
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          pip install dist/*linux*.whl
+          pip install wheelhouse/*linux*.whl
       - name: Install annlite win
         if: ${{ matrix.os == 'windows-latest'}}
         run: |
-          pip install --find-links=dist/ annlite
+          pip install --find-links=wheelhouse/ annlite
       - name: Test unix
         id: test_unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   core-test:
-    needs: [prep-testbed, build-wheels, build-sdist]
+    needs: [prep-testbed]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install annlite win
         if: ${{ matrix.os == 'windows-latest'}}
         run: |
-          pip install --find-links=wheelhouse/ annlite
+          pip install --pre --find-links=wheelhouse/ annlite
       - name: Test unix
         id: test_unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,20 +175,6 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
-  upload-test:
-    needs: [core-test]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN_TEST }}
-          repository_url: https://test.pypi.org/legacy/
-
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     needs: [core-test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,23 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
-  build-wheels:
+  core-test:
+    needs: [prep-testbed, build-wheels, build-sdist]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        cibw_arch: ["auto64"]
         cpython-version: ["cp37-*"]
+        python-version: [3.7]
+        cibw_arch: ["auto64"]
+        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v3
-      - name: Build wheels
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheel
         uses: pypa/cibuildwheel@v2.10.2
         with:
           package-dir: ./
@@ -114,45 +120,16 @@ jobs:
           CIBW_BUILD: ${{ matrix.cpython-version }}
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          CIBW_OUTPUT_DIR: "dist"
           CIBW_BUILD_FRONTEND: build
+      - uses: actions/checkout@v3
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
-
-  build-sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build sdist
-        run: pipx run build --sdist
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
-
-  core-test:
-    needs: [prep-testbed, build-wheels, build-sdist]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.7]
-        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
-    steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
+          path: ./dist/*.whl
       - name: Prepare enviroment
         run: |
           python -m pip install --upgrade pip
           pip install jina
-          pip install cibuildwheel
           pip install --pre docarray
           pip install pytest pytest-html pytest-cov pytest-mock pytest-repeat pytest-custom-exit-code pytest-timeout pytest-reraise
       - name: Install annlite unix

--- a/annlite/__init__.py
+++ b/annlite/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.14'
+__version__ = '0.3.14.dev11'
 
 from .index import AnnLite

--- a/annlite/__init__.py
+++ b/annlite/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.14.dev11'
+__version__ = '0.3.14'
 
 from .index import AnnLite

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,7 +37,7 @@ function pub_pypi {
     # publish to pypi
     pip install build
     python -m build --sdist
-    twine upload dist/*
+    twine upload --repository testpypi dist/*
     clean_build
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,10 +13,10 @@ RELEASENOTE='./node_modules/.bin/git-release-notes'
 
 
 function clean_build {
-  rm -rf dist
-  rm -rf annlite/*.so
-  rm -rf *.egg-info
-  rm -rf build
+    rm -rf dist
+    rm -rf annlite/*.so
+    rm -rf *.egg-info
+    rm -rf build
 }
 
 

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -11,35 +11,20 @@ INIT_FILE='annlite/__init__.py'
 VER_TAG='__version__ = '
 RELEASENOTE='./node_modules/.bin/git-release-notes'
 
-
-function clean_build {
-  rm -rf dist
-  rm -rf annlite/*.so
-  rm -rf *.egg-info
-  rm -rf build
+function escape_slashes {
+    sed 's/\//\\\//g'
 }
 
+function update_ver_line {
+    local OLD_LINE_PATTERN=$1
+    local NEW_LINE=$2
+    local FILE=$3
 
-function pub_pypi {
-    # publish to pypi
-    twine upload --repository testpypi dist/*
-    clean_build
+    local NEW=$(echo "${NEW_LINE}" | escape_slashes)
+    sed -i '/'"${OLD_LINE_PATTERN}"'/s/.*/'"${NEW}"'/' "${FILE}"
+    head -n10 ${FILE}
 }
 
-function git_commit {
-    git config --local user.email "dev-bot@jina.ai"
-    git config --local user.name "Jina Dev Bot"
-    git tag "v$RELEASE_VER" -m "$(cat ./CHANGELOG.tmp)"
-    git add $INIT_FILE ./CHANGELOG.md
-    git commit -m "chore(version): the next version will be $NEXT_VER" -m "build($RELEASE_ACTOR): $RELEASE_REASON"
-}
-
-
-function make_release_note {
-    ${RELEASENOTE} ${LAST_VER}..HEAD .github/release-template.ejs > ./CHANGELOG.tmp
-    head -n10 ./CHANGELOG.tmp
-    printf '\n%s\n\n%s\n%s\n\n%s\n\n%s\n\n' "$(cat ./CHANGELOG.md)" "<a name="release-note-${RELEASE_VER//\./-}"></a>" "## Release Note (\`${RELEASE_VER}\`)" "> Release time: $(date +'%Y-%m-%d %H:%M:%S')" "$(cat ./CHANGELOG.tmp)" > ./CHANGELOG.md
-}
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
@@ -67,12 +52,9 @@ if [[ $1 == "final" ]]; then
   NEXT_VER=$(echo $RELEASE_VER | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')
   printf "bump master version to: \e[1;32m$NEXT_VER\e[0m\n"
 
-  make_release_note
-  pub_pypi
+  VER_TAG_NEXT=$VER_TAG\'${NEXT_VER}\'
+  update_ver_line "$VER_TAG" "$VER_TAG_NEXT" "$INIT_FILE"
 
-  RELEASE_REASON="$2"
-  RELEASE_ACTOR="$3"
-  git_commit
 elif [[ $1 == 'rc' ]]; then
   printf "this will be a release candidate: \e[1;33m$RELEASE_VER\e[0m\n"
   DOT_RELEASE_VER=$(echo $RELEASE_VER | sed "s/rc/\./")
@@ -80,18 +62,16 @@ elif [[ $1 == 'rc' ]]; then
   NEXT_VER=$(echo $NEXT_VER | sed "s/\.\([^.]*\)$/rc\1/")
   printf "bump master version to: \e[1;32m$NEXT_VER\e[0m, this will be the next version\n"
 
-  make_release_note
-  pub_pypi
-
-  RELEASE_REASON="$2"
-  RELEASE_ACTOR="$3"
-  git_commit
+  VER_TAG_NEXT=$VER_TAG\'${NEXT_VER}\'
+  update_ver_line "$VER_TAG" "$VER_TAG_NEXT" "$INIT_FILE"
+  
 else
   # as a prerelease, pypi update only, no back commit etc.
   COMMITS_SINCE_LAST_VER=$(git rev-list $LAST_VER..HEAD --count)
   NEXT_VER=$RELEASE_VER".dev"$COMMITS_SINCE_LAST_VER
   printf "this will be a developmental release: \e[1;33m$NEXT_VER\e[0m\n"
 
-  pub_pypi
+  VER_TAG_NEXT=$VER_TAG\'${NEXT_VER}\'
+  update_ver_line "$VER_TAG" "$VER_TAG_NEXT" "$INIT_FILE"
 
 fi


### PR DESCRIPTION
- Combine `build-wheels` and `core-test` to solve `Illegal instruction     (core dumped)` due to too many pipelines.
- Add macos arm64 in building wheels.