### PR TITLE
fix: bump rocksdict

### DIFF
--- a/annlite/__init__.py
+++ b/annlite/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 from .index import AnnLite

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ docarray[common]>=0.13.16
 filesplit
 loguru
 numpy
-rocksdict>=0.2.16
+rocksdict<=0.2.16
 scikit-learn


### PR DESCRIPTION
The latest `rocksdict v0.3.0` wheel cannot work on M1. Thus, in this PR, we bump the version to `rocksdict <= 0.2.16`. I have raised an issue https://github.com/Congyuwang/RocksDict/issues/25. Until this issue is resolved, we will not unpin the version bump.